### PR TITLE
feat(validator): add match exhaustiveness diagnostics for enums

### DIFF
--- a/gust-lang/src/validator.rs
+++ b/gust-lang/src/validator.rs
@@ -1,4 +1,4 @@
-use crate::ast::{Block, Expr, Pattern, Program, StateDecl, Statement, TransitionDecl};
+use crate::ast::{Block, Expr, Pattern, Program, StateDecl, Statement, TransitionDecl, TypeDecl};
 use crate::error::{GustError, GustWarning};
 use std::collections::{HashMap, HashSet};
 use strsim::levenshtein;
@@ -25,6 +25,19 @@ pub fn validate_program(program: &Program, file: &str, source: &str) -> Validati
     let declared_machine_names: Vec<String> =
         program.machines.iter().map(|m| m.name.clone()).collect();
     let declared_machine_set: HashSet<String> = declared_machine_names.iter().cloned().collect();
+
+    // Build a map of enum name → variant names for match exhaustiveness checking
+    let enum_variants: HashMap<String, Vec<String>> = program
+        .types
+        .iter()
+        .filter_map(|t| match t {
+            TypeDecl::Enum { name, variants, .. } => {
+                let variant_names: Vec<String> = variants.iter().map(|v| v.name.clone()).collect();
+                Some((name.clone(), variant_names))
+            }
+            _ => None,
+        })
+        .collect();
 
     for machine in &program.machines {
         let state_names: Vec<String> = machine.states.iter().map(|s| s.name.clone()).collect();
@@ -200,7 +213,7 @@ pub fn validate_program(program: &Program, file: &str, source: &str) -> Validati
             }
 
             // Task 2: warn when a handler has code paths that don't end in a goto.
-            if !block_always_terminates(&handler.body) {
+            if !block_always_terminates(&handler.body, &enum_variants) {
                 let (line, col) = locator.find_handler(&handler.transition_name);
                 report.warnings.push(GustWarning {
                     file: file.to_string(),
@@ -226,6 +239,15 @@ pub fn validate_program(program: &Program, file: &str, source: &str) -> Validati
                 &declared_machine_set,
                 &declared_machine_names,
                 &locator,
+                file,
+                &mut report,
+            );
+            // Check match exhaustiveness for enum types
+            check_match_exhaustiveness(
+                &handler.body,
+                &enum_variants,
+                &locator,
+                &handler.transition_name,
                 file,
                 &mut report,
             );
@@ -277,7 +299,7 @@ pub fn validate_program(program: &Program, file: &str, source: &str) -> Validati
 
 /// Returns true when every code path through `block` ends with a `Goto` or `Return`.
 /// Used to detect handlers that might fall through without transitioning to a new state.
-fn block_always_terminates(block: &Block) -> bool {
+fn block_always_terminates(block: &Block, enum_variants: &HashMap<String, Vec<String>>) -> bool {
     match block.statements.last() {
         None => false,
         Some(Statement::Goto { .. }) => true,
@@ -289,13 +311,192 @@ fn block_always_terminates(block: &Block) -> bool {
             then_block,
             else_block: Some(else_block),
             ..
-        }) => block_always_terminates(then_block) && block_always_terminates(else_block),
+        }) => {
+            block_always_terminates(then_block, enum_variants)
+                && block_always_terminates(else_block, enum_variants)
+        }
         Some(Statement::Match { arms, .. }) => {
-            // Exhaustive only when at least one wildcard arm exists and every arm terminates.
             let has_wildcard = arms.iter().any(|a| matches!(a.pattern, Pattern::Wildcard));
-            has_wildcard && arms.iter().all(|a| block_always_terminates(&a.body))
+
+            // Check if all variants of a known enum are covered
+            let is_enum_exhaustive = if !has_wildcard {
+                match_covers_all_enum_variants(arms, enum_variants)
+            } else {
+                false
+            };
+
+            (has_wildcard || is_enum_exhaustive)
+                && arms
+                    .iter()
+                    .all(|a| block_always_terminates(&a.body, enum_variants))
         }
         Some(_) => false,
+    }
+}
+
+/// Determines the enum name being matched based on the variant patterns in the arms.
+/// Returns `Some(enum_name)` if all variant arms reference the same known enum.
+fn infer_matched_enum<'a>(
+    arms: &[crate::ast::MatchArm],
+    enum_variants: &'a HashMap<String, Vec<String>>,
+) -> Option<&'a str> {
+    // First, try to find an explicit enum_name from Pattern::Variant arms
+    for arm in arms {
+        if let Pattern::Variant {
+            enum_name: Some(en),
+            ..
+        } = &arm.pattern
+        {
+            if enum_variants.contains_key(en) {
+                return Some(enum_variants.get_key_value(en).unwrap().0.as_str());
+            }
+        }
+    }
+
+    // If no explicit enum_name, try to match variant names against known enums
+    let variant_names: Vec<&str> = arms
+        .iter()
+        .filter_map(|arm| match &arm.pattern {
+            Pattern::Variant { variant, .. } => Some(variant.as_str()),
+            _ => None,
+        })
+        .collect();
+
+    if variant_names.is_empty() {
+        return None;
+    }
+
+    // Find an enum where all variant names from the arms are valid variants
+    for (enum_name, variants) in enum_variants {
+        if variant_names
+            .iter()
+            .all(|v| variants.iter().any(|ev| ev == v))
+        {
+            return Some(enum_name.as_str());
+        }
+    }
+
+    None
+}
+
+/// Returns true if the match arms cover all variants of a known enum.
+fn match_covers_all_enum_variants(
+    arms: &[crate::ast::MatchArm],
+    enum_variants: &HashMap<String, Vec<String>>,
+) -> bool {
+    let enum_name = match infer_matched_enum(arms, enum_variants) {
+        Some(name) => name,
+        None => return false,
+    };
+
+    let all_variants = match enum_variants.get(enum_name) {
+        Some(v) => v,
+        None => return false,
+    };
+
+    let covered: HashSet<&str> = arms
+        .iter()
+        .filter_map(|arm| match &arm.pattern {
+            Pattern::Variant { variant, .. } => Some(variant.as_str()),
+            _ => None,
+        })
+        .collect();
+
+    all_variants.iter().all(|v| covered.contains(v.as_str()))
+}
+
+/// Walks a block recursively and emits warnings for non-exhaustive match statements
+/// on known enum types.
+fn check_match_exhaustiveness(
+    block: &Block,
+    enum_variants: &HashMap<String, Vec<String>>,
+    locator: &SourceLocator<'_>,
+    handler_name: &str,
+    file: &str,
+    report: &mut ValidationReport,
+) {
+    for stmt in &block.statements {
+        match stmt {
+            Statement::Match { arms, .. } => {
+                // Recurse into arm bodies first
+                for arm in arms {
+                    check_match_exhaustiveness(
+                        &arm.body,
+                        enum_variants,
+                        locator,
+                        handler_name,
+                        file,
+                        report,
+                    );
+                }
+
+                // Check exhaustiveness for this match
+                let has_wildcard = arms.iter().any(|a| matches!(a.pattern, Pattern::Wildcard));
+                if has_wildcard {
+                    continue; // Wildcard covers everything
+                }
+
+                if let Some(enum_name) = infer_matched_enum(arms, enum_variants) {
+                    let all_variants = &enum_variants[enum_name];
+                    let covered: HashSet<&str> = arms
+                        .iter()
+                        .filter_map(|arm| match &arm.pattern {
+                            Pattern::Variant { variant, .. } => Some(variant.as_str()),
+                            _ => None,
+                        })
+                        .collect();
+
+                    let missing: Vec<&str> = all_variants
+                        .iter()
+                        .filter(|v| !covered.contains(v.as_str()))
+                        .map(|v| v.as_str())
+                        .collect();
+
+                    if !missing.is_empty() {
+                        let (line, col) = locator.find_handler(handler_name);
+                        report.warnings.push(GustWarning {
+                            file: file.to_string(),
+                            line,
+                            col,
+                            message: format!(
+                                "non-exhaustive match on enum '{}': missing variant(s) {}",
+                                enum_name,
+                                missing.join(", ")
+                            ),
+                            note: Some(
+                                "add the missing variants or a wildcard '_' arm to ensure all cases are handled"
+                                    .to_string(),
+                            ),
+                        });
+                    }
+                }
+            }
+            Statement::If {
+                then_block,
+                else_block,
+                ..
+            } => {
+                check_match_exhaustiveness(
+                    then_block,
+                    enum_variants,
+                    locator,
+                    handler_name,
+                    file,
+                    report,
+                );
+                if let Some(else_block) = else_block {
+                    check_match_exhaustiveness(
+                        else_block,
+                        enum_variants,
+                        locator,
+                        handler_name,
+                        file,
+                        report,
+                    );
+                }
+            }
+            _ => {}
+        }
     }
 }
 

--- a/gust-lang/tests/diagnostics_validation.rs
+++ b/gust-lang/tests/diagnostics_validation.rs
@@ -462,3 +462,164 @@ machine Demo {
         report.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
     );
 }
+
+#[test]
+fn validator_warns_on_non_exhaustive_enum_match() {
+    let source = r#"
+enum Status {
+    Pending,
+    Running,
+    Done,
+}
+
+machine Tracker {
+    state Idle(status: Status)
+    state Finished(msg: String)
+
+    transition finish: Idle -> Finished
+
+    on finish() {
+        match status {
+            Status::Pending => { goto Finished("pending"); }
+            Status::Done => { goto Finished("done"); }
+        }
+    }
+}
+"#;
+    let program = parse_program_with_errors(source, "test.gu").expect("should parse");
+    let report = validate_program(&program, "test.gu", source);
+
+    assert!(
+        report.warnings.iter().any(
+            |w| w.message.contains("non-exhaustive match on enum 'Status'")
+                && w.message.contains("Running")
+        ),
+        "should warn about missing variant 'Running', got warnings: {:?}",
+        report
+            .warnings
+            .iter()
+            .map(|w| &w.message)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn validator_no_warning_on_exhaustive_enum_match() {
+    let source = r#"
+enum Status {
+    Pending,
+    Done,
+}
+
+machine Tracker {
+    state Idle(status: Status)
+    state Finished(msg: String)
+
+    transition finish: Idle -> Finished
+
+    on finish() {
+        match status {
+            Status::Pending => { goto Finished("pending"); }
+            Status::Done => { goto Finished("done"); }
+        }
+    }
+}
+"#;
+    let program = parse_program_with_errors(source, "test.gu").expect("should parse");
+    let report = validate_program(&program, "test.gu", source);
+
+    assert!(
+        !report
+            .warnings
+            .iter()
+            .any(|w| w.message.contains("non-exhaustive match")),
+        "should not warn on exhaustive match, got warnings: {:?}",
+        report
+            .warnings
+            .iter()
+            .map(|w| &w.message)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn validator_no_warning_on_match_with_wildcard() {
+    let source = r#"
+enum Status {
+    Pending,
+    Running,
+    Done,
+}
+
+machine Tracker {
+    state Idle(status: Status)
+    state Finished(msg: String)
+
+    transition finish: Idle -> Finished
+
+    on finish() {
+        match status {
+            Status::Done => { goto Finished("done"); }
+            _ => { goto Finished("other"); }
+        }
+    }
+}
+"#;
+    let program = parse_program_with_errors(source, "test.gu").expect("should parse");
+    let report = validate_program(&program, "test.gu", source);
+
+    assert!(
+        !report
+            .warnings
+            .iter()
+            .any(|w| w.message.contains("non-exhaustive match")),
+        "should not warn when wildcard arm is present, got warnings: {:?}",
+        report
+            .warnings
+            .iter()
+            .map(|w| &w.message)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn validator_exhaustive_enum_match_terminates_handler() {
+    // An exhaustive enum match where every arm has a goto should not produce
+    // the "code paths that don't end with a goto" warning.
+    let source = r#"
+enum Action {
+    Start,
+    Stop,
+}
+
+machine Worker {
+    state Idle(action: Action)
+    state Running
+    state Stopped
+
+    transition decide: Idle -> Running | Stopped
+
+    on decide() {
+        match action {
+            Action::Start => { goto Running; }
+            Action::Stop => { goto Stopped; }
+        }
+    }
+}
+"#;
+    let program = parse_program_with_errors(source, "test.gu").expect("should parse");
+    let report = validate_program(&program, "test.gu", source);
+
+    assert!(
+        !report
+            .warnings
+            .iter()
+            .any(|w| w.message.contains("don't end with a goto")),
+        "exhaustive enum match with gotos should count as terminating, got warnings: {:?}",
+        report
+            .warnings
+            .iter()
+            .map(|w| &w.message)
+            .collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
## Summary

Adds non-exhaustive match detection for enum types in the validator. When a `match` expression covers variants of a known enum but is missing one or more variants (and has no wildcard `_` arm), the validator now emits a warning listing the missing variants.

Additionally, exhaustive enum matches (all variants covered) are now recognized as terminating — they no longer trigger the false "code paths that don't end with a goto" warning.

## Changes

- `gust-lang/src/validator.rs` — build enum variant map during validation; new helpers `infer_matched_enum`, `match_covers_all_enum_variants`, `check_match_exhaustiveness`; updated `block_always_terminates` to recognize exhaustive enum matches
- `gust-lang/tests/diagnostics_validation.rs` — 4 new tests covering: non-exhaustive warning, exhaustive no-warning, wildcard no-warning, and exhaustive-as-terminator

## Test Plan

- [x] `cargo test --workspace --all-targets --all-features` — all pass
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] 4 new targeted tests for the feature

---
Generated by autonomous-work agent