### PR TITLE
test(cli): add integration tests for CLI subcommands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -57,6 +66,21 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "assert_cmd"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a686bbee5efb88a82df0621b236e74d925f470e5445d3220a5648b892ec99c9"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
 
 [[package]]
 name = "async-trait"
@@ -120,6 +144,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -222,6 +257,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -263,6 +304,15 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "fnv"
@@ -418,10 +468,12 @@ dependencies = [
 name = "gust-cli"
 version = "0.1.0"
 dependencies = [
+ "assert_cmd",
  "clap",
  "gust-lang",
  "notify",
  "notify-debouncer-mini",
+ "predicates",
  "tempfile",
  "walkdir",
 ]
@@ -750,6 +802,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "notify"
 version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -926,6 +984,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1029,6 +1117,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.11.0",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1226,6 +1337,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"

--- a/gust-cli/Cargo.toml
+++ b/gust-cli/Cargo.toml
@@ -17,3 +17,5 @@ walkdir = "2"
 
 [dev-dependencies]
 tempfile = "3"
+assert_cmd = "2"
+predicates = "3"

--- a/gust-cli/tests/cli_integration.rs
+++ b/gust-cli/tests/cli_integration.rs
@@ -1,0 +1,456 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::tempdir;
+
+/// A minimal valid Gust program used as a test fixture.
+const VALID_GU: &str = r#"machine Light {
+    state Off()
+    state On()
+    transition toggle: Off -> On
+    transition turn_off: On -> Off
+    on toggle(ctx: Off) {
+        goto On();
+    }
+    on turn_off(ctx: On) {
+        goto Off();
+    }
+}
+"#;
+
+/// A syntactically invalid Gust program.
+const INVALID_GU: &str = r#"machine Broken {
+    state Off(
+}
+"#;
+
+/// A semantically invalid Gust program (references nonexistent state).
+const SEMANTIC_ERROR_GU: &str = r#"machine Bad {
+    state Off()
+    transition go: Off -> Nowhere
+    on go(ctx: Off) {
+        goto Nowhere();
+    }
+}
+"#;
+
+/// Helper: create a temp directory with a .gu file and return (dir, file_path).
+fn write_fixture(content: &str, filename: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempdir().expect("create tempdir");
+    let path = dir.path().join(filename);
+    fs::write(&path, content).expect("write fixture file");
+    (dir, path)
+}
+
+fn gust_cmd() -> Command {
+    Command::cargo_bin("gust").expect("binary 'gust' should be built")
+}
+
+// ─── build subcommand ────────────────────────────────────────────────────────
+
+#[test]
+fn build_rust_produces_g_rs_file() {
+    let (_dir, gu_path) = write_fixture(VALID_GU, "light.gu");
+
+    gust_cmd()
+        .args(["build", gu_path.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(".g.rs"));
+
+    let generated = gu_path.with_extension("g.rs");
+    assert!(generated.exists(), "expected {generated:?} to exist");
+    let content = fs::read_to_string(&generated).unwrap();
+    assert!(
+        content.contains("Light"),
+        "generated Rust code should reference the machine name"
+    );
+}
+
+#[test]
+fn build_rust_with_output_dir() {
+    let (_dir, gu_path) = write_fixture(VALID_GU, "light.gu");
+    let out_dir = _dir.path().join("out");
+
+    gust_cmd()
+        .args([
+            "build",
+            gu_path.to_str().unwrap(),
+            "--output",
+            out_dir.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let generated = out_dir.join("light.g.rs");
+    assert!(generated.exists(), "expected {generated:?} in output dir");
+}
+
+#[test]
+fn build_go_produces_g_go_file() {
+    let (_dir, gu_path) = write_fixture(VALID_GU, "light.gu");
+
+    gust_cmd()
+        .args([
+            "build",
+            gu_path.to_str().unwrap(),
+            "--target",
+            "go",
+            "--package",
+            "mypkg",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(".g.go"));
+
+    let generated = gu_path.with_extension("g.go");
+    assert!(generated.exists(), "expected {generated:?} to exist");
+    let content = fs::read_to_string(&generated).unwrap();
+    assert!(
+        content.contains("mypkg"),
+        "generated Go code should contain the package name"
+    );
+}
+
+#[test]
+fn build_wasm_produces_g_wasm_rs_file() {
+    let (_dir, gu_path) = write_fixture(VALID_GU, "light.gu");
+
+    gust_cmd()
+        .args(["build", gu_path.to_str().unwrap(), "--target", "wasm"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(".g.wasm.rs"));
+
+    let generated = gu_path.parent().unwrap().join("light.g.wasm.rs");
+    assert!(generated.exists(), "expected {generated:?} to exist");
+}
+
+#[test]
+fn build_nostd_produces_g_nostd_rs_file() {
+    let (_dir, gu_path) = write_fixture(VALID_GU, "light.gu");
+
+    gust_cmd()
+        .args(["build", gu_path.to_str().unwrap(), "--target", "nostd"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(".g.nostd.rs"));
+
+    let generated = gu_path.parent().unwrap().join("light.g.nostd.rs");
+    assert!(generated.exists(), "expected {generated:?} to exist");
+}
+
+#[test]
+fn build_ffi_produces_rs_and_header() {
+    let (_dir, gu_path) = write_fixture(VALID_GU, "light.gu");
+
+    gust_cmd()
+        .args(["build", gu_path.to_str().unwrap(), "--target", "ffi"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(".g.ffi.rs"));
+
+    let rs_file = gu_path.parent().unwrap().join("light.g.ffi.rs");
+    let h_file = gu_path.parent().unwrap().join("light.g.h");
+    assert!(rs_file.exists(), "expected FFI .rs file");
+    assert!(h_file.exists(), "expected FFI .h header file");
+}
+
+#[test]
+fn build_invalid_target_fails() {
+    let (_dir, gu_path) = write_fixture(VALID_GU, "light.gu");
+
+    gust_cmd()
+        .args(["build", gu_path.to_str().unwrap(), "--target", "java"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("unsupported target"));
+}
+
+#[test]
+fn build_missing_file_fails() {
+    gust_cmd()
+        .args(["build", "/nonexistent/path/foo.gu"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot read"));
+}
+
+#[test]
+fn build_invalid_syntax_fails() {
+    let (_dir, gu_path) = write_fixture(INVALID_GU, "broken.gu");
+
+    gust_cmd()
+        .args(["build", gu_path.to_str().unwrap()])
+        .assert()
+        .failure();
+}
+
+// ─── check subcommand ────────────────────────────────────────────────────────
+
+#[test]
+fn check_valid_file_succeeds() {
+    let (_dir, gu_path) = write_fixture(VALID_GU, "light.gu");
+
+    gust_cmd()
+        .args(["check", gu_path.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Check passed"));
+}
+
+#[test]
+fn check_invalid_syntax_fails() {
+    let (_dir, gu_path) = write_fixture(INVALID_GU, "broken.gu");
+
+    gust_cmd()
+        .args(["check", gu_path.to_str().unwrap()])
+        .assert()
+        .failure();
+}
+
+#[test]
+fn check_semantic_error_shows_diagnostics() {
+    let (_dir, gu_path) = write_fixture(SEMANTIC_ERROR_GU, "bad.gu");
+
+    gust_cmd()
+        .args(["check", gu_path.to_str().unwrap()])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Nowhere"));
+}
+
+#[test]
+fn check_missing_file_fails() {
+    gust_cmd()
+        .args(["check", "/nonexistent/path/foo.gu"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot read"));
+}
+
+// ─── fmt subcommand ──────────────────────────────────────────────────────────
+
+#[test]
+fn fmt_formats_a_valid_file() {
+    // Use poorly formatted source to verify formatting occurs
+    let messy_gu = "machine Light {\nstate Off()\n  state On()\ntransition toggle: Off -> On\ntransition turn_off: On -> Off\non toggle(ctx: Off) {\ngoto On();\n}\non turn_off(ctx: On) {\ngoto Off();\n}\n}\n";
+    let (_dir, gu_path) = write_fixture(messy_gu, "light.gu");
+
+    gust_cmd()
+        .args(["fmt", gu_path.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Formatted"));
+
+    let formatted = fs::read_to_string(&gu_path).unwrap();
+    // After formatting, indentation should be consistent (4 spaces)
+    assert!(
+        formatted.contains("    state Off"),
+        "expected formatted output to have consistent indentation"
+    );
+}
+
+#[test]
+fn fmt_missing_file_fails() {
+    gust_cmd()
+        .args(["fmt", "/nonexistent/path/foo.gu"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot read"));
+}
+
+// ─── parse subcommand ────────────────────────────────────────────────────────
+
+#[test]
+fn parse_outputs_ast_debug() {
+    let (_dir, gu_path) = write_fixture(VALID_GU, "light.gu");
+
+    gust_cmd()
+        .args(["parse", gu_path.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Light"))
+        .stdout(predicate::str::contains("Off"))
+        .stdout(predicate::str::contains("On"))
+        .stdout(predicate::str::contains("toggle"));
+}
+
+#[test]
+fn parse_invalid_syntax_fails() {
+    let (_dir, gu_path) = write_fixture(INVALID_GU, "broken.gu");
+
+    gust_cmd()
+        .args(["parse", gu_path.to_str().unwrap()])
+        .assert()
+        .failure();
+}
+
+#[test]
+fn parse_missing_file_fails() {
+    gust_cmd()
+        .args(["parse", "/nonexistent/path/foo.gu"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot read"));
+}
+
+// ─── diagram subcommand ──────────────────────────────────────────────────────
+
+#[test]
+fn diagram_outputs_mermaid_to_stdout() {
+    let (_dir, gu_path) = write_fixture(VALID_GU, "light.gu");
+
+    gust_cmd()
+        .args(["diagram", gu_path.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("stateDiagram-v2"))
+        .stdout(predicate::str::contains("Off"))
+        .stdout(predicate::str::contains("On"))
+        .stdout(predicate::str::contains("toggle"));
+}
+
+#[test]
+fn diagram_writes_to_output_file() {
+    let (_dir, gu_path) = write_fixture(VALID_GU, "light.gu");
+    let out_file = _dir.path().join("diagram.md");
+
+    gust_cmd()
+        .args([
+            "diagram",
+            gu_path.to_str().unwrap(),
+            "--output",
+            out_file.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Wrote"));
+
+    let content = fs::read_to_string(&out_file).unwrap();
+    assert!(
+        content.contains("stateDiagram-v2"),
+        "output file should contain Mermaid diagram"
+    );
+}
+
+#[test]
+fn diagram_filters_by_machine_name() {
+    let (_dir, gu_path) = write_fixture(VALID_GU, "light.gu");
+
+    gust_cmd()
+        .args(["diagram", gu_path.to_str().unwrap(), "--machine", "Light"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("stateDiagram-v2"));
+}
+
+#[test]
+fn diagram_unknown_machine_fails() {
+    let (_dir, gu_path) = write_fixture(VALID_GU, "light.gu");
+
+    gust_cmd()
+        .args([
+            "diagram",
+            gu_path.to_str().unwrap(),
+            "--machine",
+            "NonExistent",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("not found"));
+}
+
+#[test]
+fn diagram_missing_file_fails() {
+    gust_cmd()
+        .args(["diagram", "/nonexistent/path/foo.gu"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot read"));
+}
+
+// ─── init subcommand ─────────────────────────────────────────────────────────
+
+#[test]
+fn init_creates_project_scaffold() {
+    let dir = tempdir().expect("create tempdir");
+    let project_name = "test_project";
+
+    gust_cmd()
+        .current_dir(dir.path())
+        .args(["init", project_name])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Initialized"));
+
+    let project_dir = dir.path().join(project_name);
+    assert!(project_dir.join("Cargo.toml").exists(), "Cargo.toml");
+    assert!(project_dir.join("build.rs").exists(), "build.rs");
+    assert!(project_dir.join("src/main.rs").exists(), "src/main.rs");
+    assert!(
+        project_dir.join("src/payment.gu").exists(),
+        "src/payment.gu"
+    );
+    assert!(project_dir.join("README.md").exists(), "README.md");
+}
+
+#[test]
+fn init_fails_if_directory_exists() {
+    let dir = tempdir().expect("create tempdir");
+    let project_name = "existing_dir";
+    fs::create_dir(dir.path().join(project_name)).expect("create dir");
+
+    gust_cmd()
+        .current_dir(dir.path())
+        .args(["init", project_name])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("already exists"));
+}
+
+#[test]
+fn init_rejects_invalid_project_name() {
+    let dir = tempdir().expect("create tempdir");
+
+    gust_cmd()
+        .current_dir(dir.path())
+        .args(["init", "bad name"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Cargo compatibility"));
+}
+
+// ─── general CLI behavior ────────────────────────────────────────────────────
+
+#[test]
+fn no_args_shows_help() {
+    gust_cmd()
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Usage"));
+}
+
+#[test]
+fn version_flag_shows_version() {
+    gust_cmd()
+        .arg("--version")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("gust"));
+}
+
+#[test]
+fn help_flag_shows_help() {
+    gust_cmd()
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Gust"))
+        .stdout(predicate::str::contains("build"))
+        .stdout(predicate::str::contains("check"))
+        .stdout(predicate::str::contains("fmt"))
+        .stdout(predicate::str::contains("parse"))
+        .stdout(predicate::str::contains("diagram"))
+        .stdout(predicate::str::contains("init"));
+}


### PR DESCRIPTION
## Summary

Adds 29 integration tests for the `gust-cli` binary, covering all user-facing subcommands. The CLI previously had zero test coverage (747 LOC untested).

## Changes

- New file: `gust-cli/tests/cli_integration.rs` (29 tests)
- Added `assert_cmd` and `predicates` dev-dependencies to `gust-cli/Cargo.toml`

### Test coverage by subcommand

| Subcommand | Tests | Scenarios |
|------------|-------|-----------|
| `build` | 9 | Rust/Go/WASM/nostd/FFI output, custom output dir, invalid target, missing file, syntax error |
| `check` | 4 | Valid file, syntax error, semantic error, missing file |
| `fmt` | 2 | Formats file, missing file error |
| `parse` | 3 | Valid AST output, syntax error, missing file |
| `diagram` | 5 | Stdout output, file output, machine filter, unknown machine, missing file |
| `init` | 3 | Full scaffold creation, existing dir error, invalid name |
| `general` | 3 | No args shows usage, --version, --help |

## Test Plan

- [x] `cargo test -p gust-cli` — 29/29 pass
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

---
Generated by autonomous-work agent