### PR TITLE
docs(lang): add comprehensive rustdoc for all public APIs

### DIFF
--- a/gust-lang/src/ast.rs
+++ b/gust-lang/src/ast.rs
@@ -1,34 +1,65 @@
-/// Abstract Syntax Tree for the Gust language
-/// Every .gu file parses into a `Program` containing types and machines.
+//! Abstract Syntax Tree (AST) for the Gust language.
+//!
+//! Every `.gu` source file is parsed into a [`Program`], the top-level node
+//! containing use-paths, type declarations, channel declarations, and machine
+//! declarations. The AST is produced by [`crate::parser::parse_program`] and
+//! consumed by the validator and code generators.
 
+/// Root AST node representing an entire `.gu` source file.
+///
+/// A program is composed of four kinds of top-level declarations that appear
+/// in any order: imports (`use`), types (`type` / `enum`), channels, and
+/// machines.
 #[derive(Debug, Clone)]
 pub struct Program {
+    /// Import paths (e.g. `use std::collections::HashMap`).
     pub uses: Vec<UsePath>,
+    /// Struct and enum type declarations defined outside machines.
     pub types: Vec<TypeDecl>,
+    /// Channel declarations for inter-machine communication.
     pub channels: Vec<ChannelDecl>,
+    /// State machine declarations -- the core abstraction in Gust.
     pub machines: Vec<MachineDecl>,
 }
 
+/// A `use` import path (e.g. `use std::collections::HashMap`).
+///
+/// Segments are the individual components split by `::`.
 #[derive(Debug, Clone)]
 pub struct UsePath {
+    /// Path segments (e.g. `["std", "collections", "HashMap"]`).
     pub segments: Vec<String>,
 }
 
 // === Type Declarations ===
 
+/// A top-level type declaration -- either a struct or an enum.
+///
+/// In Gust syntax:
+/// ```text
+/// type Config { retries: i64, timeout: i64 }
+/// enum Status { Ok, Error(String) }
+/// ```
 #[derive(Debug, Clone)]
 pub enum TypeDecl {
+    /// A product type with named fields: `type Name { field: Type, ... }`.
     Struct {
+        /// The type name (PascalCase by convention).
         name: String,
+        /// Named fields with their types.
         fields: Vec<Field>,
     },
+    /// A sum type with variants: `enum Name { A, B(Type), ... }`.
     Enum {
+        /// The enum name (PascalCase by convention).
         name: String,
+        /// Enum variants, each optionally carrying payload types.
         variants: Vec<EnumVariant>,
     },
 }
 
 impl TypeDecl {
+    /// Returns the declared name of this type.
     pub fn name(&self) -> &str {
         match self {
             TypeDecl::Struct { name, .. } => name,
@@ -36,6 +67,7 @@ impl TypeDecl {
         }
     }
 
+    /// Returns the fields for a struct variant, or an empty slice for enums.
     pub fn fields(&self) -> &[Field] {
         match self {
             TypeDecl::Struct { fields, .. } => fields,
@@ -44,219 +76,423 @@ impl TypeDecl {
     }
 }
 
+/// A single variant of a Gust `enum` declaration.
+///
+/// Variants may carry zero or more positional payload types (e.g. `Error(String)`).
 #[derive(Debug, Clone)]
 pub struct EnumVariant {
+    /// Variant name (PascalCase by convention).
     pub name: String,
+    /// Positional payload types (empty for unit variants like `Ok`).
     pub payload: Vec<TypeExpr>,
 }
 
+/// A named field in a struct or state declaration.
 #[derive(Debug, Clone)]
 pub struct Field {
+    /// Field name (snake_case by convention).
     pub name: String,
+    /// The field's type expression.
     pub ty: TypeExpr,
 }
 
+/// A type expression appearing in field declarations, parameters, or return types.
+///
+/// Covers the type syntax supported by Gust: unit `()`, simple names, generics,
+/// and tuples.
 #[derive(Debug, Clone)]
 pub enum TypeExpr {
+    /// The unit type `()`.
     Unit,
+    /// A simple named type (e.g. `String`, `i64`, `Config`).
     Simple(String),
+    /// A generic type (e.g. `Vec<String>`, `Option<i64>`).
     Generic(String, Vec<TypeExpr>),
+    /// A tuple type (e.g. `(i64, String)`).
     Tuple(Vec<TypeExpr>),
 }
 
 // === Machine Declarations ===
 
+/// A state machine declaration -- the primary abstraction in Gust.
+///
+/// Machines contain states, transitions between states, handler
+/// implementations for each transition, and optional effect declarations
+/// for side-effect injection.
+///
+/// ```text
+/// machine OrderProcessor {
+///     state Pending(order_id: String)
+///     state Confirmed
+///     transition confirm: Pending -> Confirmed
+///     effect save_order(id: String) -> bool
+///     on confirm(ctx: Ctx) { goto Confirmed; }
+/// }
+/// ```
 #[derive(Debug, Clone)]
 pub struct MachineDecl {
+    /// Machine name (PascalCase by convention).
     pub name: String,
+    /// Generic type parameters (e.g. `<T: Send>`).
     pub generic_params: Vec<GenericParam>,
+    /// Channel names this machine sends to.
     pub sends: Vec<String>,
+    /// Channel names this machine receives from.
     pub receives: Vec<String>,
+    /// Child machines supervised by this machine.
     pub supervises: Vec<SupervisionSpec>,
+    /// State declarations (the first state is the initial state).
     pub states: Vec<StateDecl>,
+    /// Transition declarations defining valid state changes.
     pub transitions: Vec<TransitionDecl>,
+    /// Handler implementations for transitions.
     pub handlers: Vec<OnHandler>,
+    /// Effect declarations for external side effects.
     pub effects: Vec<EffectDecl>,
 }
 
+/// A generic type parameter with optional trait bounds.
+///
+/// Corresponds to `<T: Bound1 + Bound2>` in machine declarations.
 #[derive(Debug, Clone)]
 pub struct GenericParam {
+    /// Parameter name (e.g. `T`).
     pub name: String,
+    /// Trait bounds (e.g. `["Send", "Sync"]`).
     pub bounds: Vec<String>,
 }
 
+/// A state declaration within a machine.
+///
+/// States may carry named fields that hold data while the machine is in
+/// that state. The first declared state is the machine's initial state.
+///
+/// ```text
+/// state Pending(order_id: String, retries: i64)
+/// state Complete
+/// ```
 #[derive(Debug, Clone)]
 pub struct StateDecl {
+    /// State name (PascalCase by convention).
     pub name: String,
+    /// Fields carried by this state (empty for unit states).
     pub fields: Vec<Field>,
 }
 
+/// A transition declaration defining a valid state change.
+///
+/// Transitions name an event, specify a source state, and list one or more
+/// possible target states (for branching transitions). An optional timeout
+/// can trigger automatic transition after a duration.
+///
+/// ```text
+/// transition validate: Pending -> Validated | Failed timeout 30s
+/// ```
 #[derive(Debug, Clone)]
 pub struct TransitionDecl {
+    /// Transition name (snake_case by convention).
     pub name: String,
+    /// Source state name.
     pub from: String,
-    pub targets: Vec<String>, // e.g., Validated | Failed
+    /// Target state names (e.g. `["Validated", "Failed"]`).
+    pub targets: Vec<String>,
+    /// Optional timeout duration that auto-triggers this transition.
     pub timeout: Option<DurationSpec>,
 }
 
+/// An effect declaration for external side effects.
+///
+/// Effects define an interface for I/O or other impure operations that the
+/// machine needs but does not implement. Code generators produce a trait
+/// (Rust) or interface (Go) from these declarations.
+///
+/// ```text
+/// effect save_order(id: String) -> bool
+/// async effect fetch_price(symbol: String) -> f64
+/// ```
 #[derive(Debug, Clone)]
 pub struct EffectDecl {
+    /// Effect name (snake_case by convention).
     pub name: String,
+    /// Parameters the effect accepts.
     pub params: Vec<Field>,
+    /// Return type of the effect.
     pub return_type: TypeExpr,
+    /// Whether the effect is async (requires `.await` in generated code).
     pub is_async: bool,
 }
 
+/// A handler implementation for a transition.
+///
+/// Handlers contain the logic that runs when a transition is triggered.
+/// They receive parameters, can access the current state via `ctx`, perform
+/// effects, and must end with a `goto` to transition to a new state.
+///
+/// ```text
+/// on validate(ctx: Ctx, input: String) {
+///     if input != "" { goto Validated; }
+///     else { goto Failed; }
+/// }
+/// ```
 #[derive(Debug, Clone)]
 pub struct OnHandler {
+    /// Name of the transition this handler implements.
     pub transition_name: String,
+    /// Handler parameters (first is typically the context parameter).
     pub params: Vec<Param>,
+    /// Optional return type (currently unsupported by codegen).
     pub return_type: Option<TypeExpr>,
+    /// The handler body containing statements.
     pub body: Block,
+    /// Whether this handler is async.
     pub is_async: bool,
 }
 
+/// A named parameter with a type annotation.
 #[derive(Debug, Clone)]
 pub struct Param {
+    /// Parameter name.
     pub name: String,
+    /// Parameter type.
     pub ty: TypeExpr,
 }
 
 // === Statements & Expressions ===
 
+/// A block of statements (the body of a handler, if-branch, or match arm).
 #[derive(Debug, Clone)]
 pub struct Block {
+    /// Ordered list of statements in this block.
     pub statements: Vec<Statement>,
 }
 
+/// A statement within a handler body or block.
 #[derive(Debug, Clone)]
 pub enum Statement {
+    /// Variable binding: `let name: Type = value;` or `let name = value;`.
     Let {
+        /// Variable name.
         name: String,
+        /// Optional explicit type annotation.
         ty: Option<TypeExpr>,
+        /// Initializer expression.
         value: Expr,
     },
+    /// Return statement: `return expr;` (currently rejected by the validator).
     Return(Expr),
+    /// Conditional: `if cond { ... } else { ... }`.
     If {
+        /// Condition expression.
         condition: Expr,
+        /// Block executed when the condition is true.
         then_block: Block,
+        /// Optional block executed when the condition is false.
         else_block: Option<Block>,
     },
+    /// State transition: `goto StateName(arg1, arg2);`.
+    ///
+    /// Arguments are positionally zipped with the target state's declared fields.
     Goto {
+        /// Target state name.
         state: String,
+        /// Arguments to pass as the target state's field values.
         args: Vec<Expr>,
     },
+    /// Effect invocation as a statement: `perform effect_name(args);`.
     Perform {
+        /// Effect name.
         effect: String,
+        /// Arguments to the effect.
         args: Vec<Expr>,
     },
+    /// Channel send: `send channel_name(message);`.
     Send {
+        /// Target channel name.
         channel: String,
+        /// Message expression to send.
         message: Expr,
     },
+    /// Spawn a child machine: `spawn MachineName(args);`.
     Spawn {
+        /// Machine name to spawn.
         machine: String,
+        /// Arguments for the spawned machine's initial state.
         args: Vec<Expr>,
     },
+    /// Pattern match: `match expr { pattern => { ... } }`.
     Match {
+        /// Expression being matched.
         scrutinee: Expr,
+        /// Match arms with patterns and bodies.
         arms: Vec<MatchArm>,
     },
+    /// A bare expression used as a statement.
     Expr(Expr),
 }
 
+/// A single arm in a `match` expression.
 #[derive(Debug, Clone)]
 pub struct MatchArm {
+    /// The pattern to match against.
     pub pattern: Pattern,
+    /// The block to execute when the pattern matches.
     pub body: Block,
 }
 
+/// A pattern in a `match` arm.
 #[derive(Debug, Clone)]
 pub enum Pattern {
+    /// Wildcard pattern `_` that matches anything.
     Wildcard,
+    /// Simple identifier pattern (binds or matches a variable).
     Ident(String),
+    /// Enum variant pattern: `EnumName::Variant(binding1, binding2)`.
     Variant {
+        /// Optional qualifying enum name (e.g. `Status` in `Status::Ok`).
         enum_name: Option<String>,
+        /// Variant name.
         variant: String,
+        /// Variable names bound from the variant's payload.
         bindings: Vec<String>,
     },
 }
 
+/// An expression node in the AST.
+///
+/// `Perform` is both an expression and a statement in Gust, allowing
+/// `let x = perform effect(args);` to capture effect return values.
 #[derive(Debug, Clone)]
 pub enum Expr {
+    /// Integer literal (e.g. `42`).
     IntLit(i64),
+    /// Floating-point literal (e.g. `3.14`).
     FloatLit(f64),
+    /// String literal (e.g. `"hello"`).
     StringLit(String),
+    /// Boolean literal (`true` or `false`).
     BoolLit(bool),
+    /// Identifier reference (e.g. `count`, `ctx`).
     Ident(String),
+    /// Field access (e.g. `ctx.count`, `order.id`).
     FieldAccess(Box<Expr>, String),
+    /// Function call (e.g. `to_string(value)`).
     FnCall(String, Vec<Expr>),
+    /// Binary operation (e.g. `a + b`, `x == y`).
     BinOp(Box<Expr>, BinOp, Box<Expr>),
+    /// Unary operation (e.g. `!flag`, `-value`).
     UnaryOp(UnaryOp, Box<Expr>),
-    Perform(String, Vec<Expr>), // effect name, arguments
-    Path(String, String),       // Enum::Variant qualified path
+    /// Effect invocation as an expression: `perform effect_name(args)`.
+    Perform(String, Vec<Expr>),
+    /// Qualified enum path: `Enum::Variant`.
+    Path(String, String),
 }
 
+/// Binary operators supported in Gust expressions.
 #[derive(Debug, Clone)]
 pub enum BinOp {
+    /// Addition (`+`).
     Add,
+    /// Subtraction (`-`).
     Sub,
+    /// Multiplication (`*`).
     Mul,
+    /// Division (`/`).
     Div,
+    /// Modulo (`%`).
     Mod,
+    /// Equality (`==`).
     Eq,
+    /// Inequality (`!=`).
     Neq,
+    /// Less than (`<`).
     Lt,
+    /// Less than or equal (`<=`).
     Lte,
+    /// Greater than (`>`).
     Gt,
+    /// Greater than or equal (`>=`).
     Gte,
+    /// Logical AND (`&&`).
     And,
+    /// Logical OR (`||`).
     Or,
 }
 
+/// Unary operators supported in Gust expressions.
 #[derive(Debug, Clone)]
 pub enum UnaryOp {
+    /// Logical negation (`!`).
     Not,
+    /// Arithmetic negation (`-`).
     Neg,
 }
 
+/// A channel declaration for inter-machine communication.
+///
+/// ```text
+/// channel events: Event { capacity: 1024, mode: broadcast }
+/// ```
 #[derive(Debug, Clone)]
 pub struct ChannelDecl {
+    /// Channel name.
     pub name: String,
+    /// Type of messages carried by this channel.
     pub message_type: TypeExpr,
+    /// Optional buffer capacity (defaults to implementation-defined).
     pub capacity: Option<i64>,
+    /// Communication mode (broadcast or mpsc).
     pub mode: ChannelMode,
 }
 
+/// The communication mode for a channel.
 #[derive(Debug, Clone, Copy)]
 pub enum ChannelMode {
+    /// Broadcast: every subscriber receives every message.
     Broadcast,
+    /// Multi-producer, single-consumer.
     Mpsc,
 }
 
+/// Specification for a supervised child machine.
 #[derive(Debug, Clone)]
 pub struct SupervisionSpec {
+    /// Name of the child machine being supervised.
     pub child_machine: String,
+    /// Restart strategy applied when the child fails.
     pub strategy: SupervisionStrategy,
 }
 
+/// Erlang/OTP-inspired supervision restart strategies.
 #[derive(Debug, Clone, Copy)]
 pub enum SupervisionStrategy {
+    /// Restart only the failed child.
     OneForOne,
+    /// Restart all children when one fails.
     OneForAll,
+    /// Restart the failed child and all children started after it.
     RestForOne,
 }
 
+/// A duration specification for transition timeouts.
+///
+/// Represents a value with a time unit (e.g. `30s`, `500ms`).
 #[derive(Debug, Clone, Copy)]
 pub struct DurationSpec {
+    /// Numeric value of the duration.
     pub value: i64,
+    /// Time unit (milliseconds, seconds, minutes, or hours).
     pub unit: TimeUnit,
 }
 
+/// Time units supported in duration specifications.
 #[derive(Debug, Clone, Copy)]
 pub enum TimeUnit {
+    /// Milliseconds (`ms`).
     Millis,
+    /// Seconds (`s`).
     Seconds,
+    /// Minutes (`m`).
     Minutes,
+    /// Hours (`h`).
     Hours,
 }

--- a/gust-lang/src/codegen.rs
+++ b/gust-lang/src/codegen.rs
@@ -1,12 +1,16 @@
-// Code generator: emits Rust source code from a Gust AST.
-//
-// Each `machine` becomes:
-//   - A state enum with serde derives
-//   - A machine struct holding the current state
-//   - An impl block with transition methods (type-checked)
-//   - Transition methods that enforce valid from-state at runtime
-//     (compile-time via enum matching / exhaustiveness)
-//   - Effect traits (if machine declares effects)
+//! Rust code generator for Gust state machines.
+//!
+//! Transforms a validated [`Program`] AST into idiomatic Rust source code.
+//! Each machine produces:
+//!
+//! - A state enum (`{Machine}State`) with serde `Serialize`/`Deserialize` derives.
+//! - A machine struct holding the current state.
+//! - An `impl` block with transition methods that enforce valid from-state at
+//!   runtime via exhaustive enum matching.
+//! - An effects trait (`{Machine}Effects`) when the machine declares effects.
+//!
+//! Generated files use the `.g.rs` extension by convention and should never
+//! be edited manually.
 
 use crate::ast::*;
 use crate::codegen_common::{
@@ -16,6 +20,22 @@ use crate::codegen_common::{
 };
 use std::collections::HashSet;
 
+/// Rust code generator.
+///
+/// Consumes a [`Program`] AST and produces a `String` containing valid Rust
+/// source code. The generated code depends on the `gust-runtime` crate and
+/// `serde` for serialization.
+///
+/// # Examples
+///
+/// ```rust
+/// use gust_lang::{parse_program, RustCodegen};
+///
+/// let source = "machine Ping { state Idle  state Active  transition go: Idle -> Active  on go(ctx: Ctx) { goto Active; } }";
+/// let ast = parse_program(source).unwrap();
+/// let code = RustCodegen::new().generate(&ast);
+/// assert!(code.contains("pub struct Ping"));
+/// ```
 pub struct RustCodegen {
     output: String,
     indent: usize,
@@ -26,6 +46,7 @@ pub struct RustCodegen {
 }
 
 impl RustCodegen {
+    /// Create a new Rust code generator with default settings.
     pub fn new() -> Self {
         Self {
             output: String::new(),
@@ -37,6 +58,11 @@ impl RustCodegen {
         }
     }
 
+    /// Generate Rust source code from a [`Program`] AST.
+    ///
+    /// This method consumes the generator and returns the complete Rust source
+    /// as a `String`. The output includes a prelude with `use` statements,
+    /// type declarations, channel structs, and machine implementations.
     pub fn generate(mut self, program: &Program) -> String {
         self.emit_prelude(program);
 

--- a/gust-lang/src/codegen_common.rs
+++ b/gust-lang/src/codegen_common.rs
@@ -329,6 +329,7 @@ fn stmt_references_ctx(stmt: &Statement) -> bool {
     }
 }
 
+/// Whether an expression references `ctx` anywhere in its tree.
 pub fn expr_references_ctx(expr: &Expr) -> bool {
     match expr {
         Expr::Ident(name) => name == "ctx",

--- a/gust-lang/src/codegen_ffi.rs
+++ b/gust-lang/src/codegen_ffi.rs
@@ -1,12 +1,34 @@
+//! C FFI code generator for Gust state machines.
+//!
+//! Produces a pair of outputs: Rust source with `#[no_mangle] extern "C"`
+//! functions, and a C header file (`.h`) with the corresponding declarations.
+//! This allows Gust machines to be used from C, C++, or any language with
+//! C FFI support.
+
 use crate::ast::Program;
 
+/// C FFI code generator.
+///
+/// Produces both Rust FFI glue and a C header file. Each machine generates:
+///
+/// - A `#[repr(C)]` state enum and handle struct.
+/// - `extern "C"` functions for creation, destruction, state query, and
+///   each transition.
+/// - A matching `.h` header with `typedef` enums, opaque handle types,
+///   and function prototypes.
 pub struct CffiCodegen;
 
 impl CffiCodegen {
+    /// Create a new C FFI code generator.
     pub fn new() -> Self {
         Self
     }
 
+    /// Generate C FFI bindings from a [`Program`] AST.
+    ///
+    /// Returns a tuple `(rust_source, c_header)` where:
+    /// - `rust_source` contains `#[no_mangle] extern "C"` functions.
+    /// - `c_header` contains the corresponding C header declarations.
     pub fn generate(&self, program: &Program) -> (String, String) {
         let mut rust = String::new();
         let mut header = String::new();

--- a/gust-lang/src/codegen_go.rs
+++ b/gust-lang/src/codegen_go.rs
@@ -1,18 +1,23 @@
-// Go Code Generator: emits Go source code from a Gust AST.
-//
-// Each `machine` becomes:
-//   - State constants via iota
-//   - A state data struct per state variant (Go lacks sum types)
-//   - An effects interface
-//   - A machine struct with current state + state data
-//   - Transition methods with runtime state validation
-//
-// Key differences from Rust codegen:
-//   - No sum types -> use state enum (iota) + interface for state data
-//   - No exhaustiveness checking -> runtime panics on invalid transitions
-//   - Effects trait -> Go interface (more idiomatic)
-//   - Serde -> json struct tags (free with encoding/json)
-//   - Error handling -> Go error returns, no Result<T,E>
+//! Go code generator for Gust state machines.
+//!
+//! Transforms a validated [`Program`] AST into idiomatic Go source code.
+//! Each machine produces:
+//!
+//! - State constants via `iota`.
+//! - A state data struct per state variant (Go lacks sum types).
+//! - An effects interface (`{Machine}Effects`).
+//! - A machine struct with current state and state data.
+//! - Transition methods with runtime state validation.
+//!
+//! Key differences from the Rust backend:
+//!
+//! - No sum types: uses a state `iota` enum + interface for state data.
+//! - No exhaustiveness checking: invalid transitions cause runtime panics.
+//! - Effects produce a Go `interface` rather than a Rust trait.
+//! - Serialization uses `json` struct tags (free with `encoding/json`).
+//! - Error handling uses Go's idiomatic `error` return values.
+//!
+//! Generated files use the `.g.go` extension by convention.
 
 use crate::ast::*;
 use crate::codegen_common::{
@@ -22,6 +27,21 @@ use crate::codegen_common::{
 };
 use std::collections::HashSet;
 
+/// Go code generator.
+///
+/// Consumes a [`Program`] AST and produces a `String` containing valid Go
+/// source code. Requires a package name for the generated Go file.
+///
+/// # Examples
+///
+/// ```rust
+/// use gust_lang::{parse_program, GoCodegen};
+///
+/// let source = "machine Ping { state Idle  state Active  transition go: Idle -> Active  on go(ctx: Ctx) { goto Active; } }";
+/// let ast = parse_program(source).unwrap();
+/// let code = GoCodegen::new().generate(&ast, "mypackage");
+/// assert!(code.contains("package mypackage"));
+/// ```
 pub struct GoCodegen {
     output: String,
     indent: usize,
@@ -34,6 +54,7 @@ pub struct GoCodegen {
 }
 
 impl GoCodegen {
+    /// Create a new Go code generator with default settings.
     pub fn new() -> Self {
         Self {
             output: String::new(),
@@ -47,6 +68,13 @@ impl GoCodegen {
         }
     }
 
+    /// Generate Go source code from a [`Program`] AST.
+    ///
+    /// The `package_name` argument sets the Go `package` declaration at the
+    /// top of the generated file.
+    ///
+    /// This method consumes the generator and returns the complete Go source
+    /// as a `String`.
     pub fn generate(mut self, program: &Program, package_name: &str) -> String {
         self.emit_prelude(program, package_name);
 

--- a/gust-lang/src/codegen_nostd.rs
+++ b/gust-lang/src/codegen_nostd.rs
@@ -1,12 +1,29 @@
+//! `no_std` code generator for Gust state machines.
+//!
+//! Produces Rust source that compiles in `#![no_std]` environments using
+//! `heapless` collections instead of `std` containers. Suitable for
+//! embedded systems and bare-metal targets where dynamic allocation is
+//! unavailable or undesirable.
+
 use crate::ast::*;
 
+/// `no_std` code generator.
+///
+/// Produces `#![no_std]` Rust code using `heapless::String` and
+/// `heapless::Vec` with fixed capacities instead of heap-allocated
+/// `std` containers.
 pub struct NoStdCodegen;
 
 impl NoStdCodegen {
+    /// Create a new `no_std` code generator.
     pub fn new() -> Self {
         Self
     }
 
+    /// Generate `no_std` Rust source code from a [`Program`] AST.
+    ///
+    /// The output begins with `#![no_std]` and `extern crate alloc`, and
+    /// uses `heapless` types for strings and vectors.
     pub fn generate(&self, program: &Program) -> String {
         let mut out = String::new();
         out.push_str("#![no_std]\n");

--- a/gust-lang/src/codegen_wasm.rs
+++ b/gust-lang/src/codegen_wasm.rs
@@ -1,12 +1,29 @@
+//! WebAssembly code generator for Gust state machines.
+//!
+//! Produces Rust source targeting `wasm32` with `wasm-bindgen` annotations.
+//! State enums use `#[repr(u32)]` for efficient JS interop, and effects
+//! are dispatched through a `GustWasmEffectAdapter` trait that bridges
+//! into JavaScript via `js_sys::Promise`.
+
 use crate::ast::*;
 
+/// WebAssembly code generator.
+///
+/// Produces `wasm-bindgen`-annotated Rust code suitable for compilation to
+/// WebAssembly. Types are annotated with `#[wasm_bindgen]` and state enums
+/// use `#[repr(u32)]` for zero-cost JS interop.
 pub struct WasmCodegen;
 
 impl WasmCodegen {
+    /// Create a new WASM code generator.
     pub fn new() -> Self {
         Self
     }
 
+    /// Generate wasm-bindgen Rust source code from a [`Program`] AST.
+    ///
+    /// The output includes `wasm_bindgen` imports, a `GustWasmEffectAdapter`
+    /// trait definition, and annotated structs/enums for each machine.
     pub fn generate(&self, program: &Program) -> String {
         let mut out = String::new();
         out.push_str("// Generated for wasm32 target\n");

--- a/gust-lang/src/error.rs
+++ b/gust-lang/src/error.rs
@@ -1,25 +1,56 @@
+//! Diagnostic types for Gust compiler errors and warnings.
+//!
+//! Both [`GustError`] and [`GustWarning`] carry source location information
+//! (file, line, column) and can be rendered into rustc-style diagnostic
+//! strings with [`GustError::render`] / [`GustWarning::render`].
+
 use colored::Colorize;
 
+/// A compile-time error produced by the parser or validator.
+///
+/// Each error carries the source location and an explanatory message. Optional
+/// `note` and `help` fields provide extra context, such as listing valid names
+/// or suggesting a typo correction (powered by Levenshtein distance).
 #[derive(Debug, Clone)]
 pub struct GustError {
+    /// Source file path (as provided by the caller).
     pub file: String,
+    /// 1-based line number in the source file.
     pub line: usize,
+    /// 1-based column number in the source file.
     pub col: usize,
+    /// Human-readable description of the error.
     pub message: String,
+    /// Optional additional context (e.g. "declared states: Idle, Running").
     pub note: Option<String>,
+    /// Optional fix suggestion (e.g. "did you mean 'state'?").
     pub help: Option<String>,
 }
 
+/// A compile-time warning produced by the validator.
+///
+/// Warnings indicate potential issues that do not prevent code generation
+/// (e.g. unreachable states, unused effects, handlers with missing `goto`).
 #[derive(Debug, Clone)]
 pub struct GustWarning {
+    /// Source file path (as provided by the caller).
     pub file: String,
+    /// 1-based line number in the source file.
     pub line: usize,
+    /// 1-based column number in the source file.
     pub col: usize,
+    /// Human-readable description of the warning.
     pub message: String,
+    /// Optional additional context.
     pub note: Option<String>,
 }
 
 impl GustError {
+    /// Render this error as a rustc-style diagnostic string.
+    ///
+    /// The output includes the error message, a source location pointer with
+    /// surrounding context lines, and optional note/help annotations.
+    /// Coloring is controlled by the `NO_COLOR` environment variable.
     pub fn render(&self, source: &str) -> String {
         render_diag(
             "error",
@@ -34,6 +65,10 @@ impl GustError {
 }
 
 impl GustWarning {
+    /// Render this warning as a rustc-style diagnostic string.
+    ///
+    /// Same format as [`GustError::render`] but with a yellow "warning" label
+    /// instead of a red "error" label.
     pub fn render(&self, source: &str) -> String {
         render_diag(
             "warning",

--- a/gust-lang/src/format.rs
+++ b/gust-lang/src/format.rs
@@ -1,11 +1,41 @@
+//! Gust source code formatter.
+//!
+//! Provides two formatting modes:
+//!
+//! - [`format_program`] -- canonical pretty-printing from the AST alone.
+//! - [`format_program_preserving`] -- preserves comments from the original
+//!   source by extracting and reinserting them at the appropriate locations.
+//!
+//! Both produce consistently indented, idiomatic Gust source text.
+
 use crate::ast::*;
 use crate::codegen_common::escape_string_literal;
 use std::collections::HashMap;
 
+/// Format a [`Program`] AST into canonical Gust source text.
+///
+/// Produces consistently indented output without any comments (since the
+/// AST does not carry comment information). Use [`format_program_preserving`]
+/// to retain comments from the original source.
+///
+/// # Examples
+///
+/// ```rust
+/// use gust_lang::{parse_program, format_program};
+///
+/// let ast = parse_program("machine Foo { state A  state B }").unwrap();
+/// let formatted = format_program(&ast);
+/// assert!(formatted.contains("machine Foo"));
+/// ```
 pub fn format_program(program: &Program) -> String {
     format_program_with_source(program, None)
 }
 
+/// Format a [`Program`] AST while preserving comments from the original source.
+///
+/// Comments are extracted from `source` and reinserted at their original
+/// positions relative to the declarations they precede. This is the
+/// recommended formatter for editor integrations and the `gust fmt` command.
 pub fn format_program_preserving(program: &Program, source: &str) -> String {
     format_program_with_source(program, Some(source))
 }

--- a/gust-lang/src/lib.rs
+++ b/gust-lang/src/lib.rs
@@ -1,3 +1,53 @@
+//! # gust-lang
+//!
+//! Core compiler library for the Gust state machine language. Gust is a
+//! type-safe DSL that compiles `.gu` source files into idiomatic Rust and Go
+//! code, with additional backends for WebAssembly, `no_std`, and C FFI.
+//!
+//! ## Compiler Pipeline
+//!
+//! ```text
+//! source.gu → Parser (PEG) → AST → Validator → Codegen → .g.rs / .g.go
+//! ```
+//!
+//! 1. **Parse** -- [`parse_program`] turns a `.gu` source string into a
+//!    [`ast::Program`] AST, or returns a human-readable error.
+//! 2. **Validate** -- [`validate_program`] performs semantic analysis on the
+//!    AST, producing a [`ValidationReport`] with errors and warnings.
+//! 3. **Generate** -- A codegen backend ([`RustCodegen`], [`GoCodegen`],
+//!    [`WasmCodegen`], [`NoStdCodegen`], or [`CffiCodegen`]) transforms the
+//!    validated AST into target-language source code.
+//!
+//! ## Quick Start
+//!
+//! ```rust
+//! use gust_lang::{parse_program, validate_program, RustCodegen};
+//!
+//! let source = r#"
+//!     machine Toggle {
+//!         state Off
+//!         state On
+//!         transition flip: Off -> On
+//!         transition reset: On -> Off
+//!         on flip(ctx: Ctx) { goto On; }
+//!         on reset(ctx: Ctx) { goto Off; }
+//!     }
+//! "#;
+//!
+//! let ast = parse_program(source).expect("parse error");
+//! let report = validate_program(&ast, "toggle.gu", source);
+//! assert!(report.is_ok());
+//!
+//! let rust_code = RustCodegen::new().generate(&ast);
+//! assert!(rust_code.contains("pub enum ToggleState"));
+//! ```
+//!
+//! ## Formatting
+//!
+//! The [`format_program`] function pretty-prints a parsed AST back into
+//! canonical Gust syntax, while [`format_program_preserving`] retains
+//! comments from the original source.
+
 pub mod ast;
 pub mod codegen;
 pub mod codegen_common;

--- a/gust-lang/src/parser.rs
+++ b/gust-lang/src/parser.rs
@@ -1,3 +1,13 @@
+//! PEG parser for the Gust language.
+//!
+//! Uses [pest](https://pest.rs) with the grammar defined in `grammar.pest`.
+//! The public entry points are [`parse_program`] (returns a plain `String`
+//! error) and [`parse_program_with_errors`] (returns a structured
+//! [`GustError`]).
+//!
+//! Internally, each PEG rule has a corresponding `parse_*` function that
+//! converts pest `Pair` nodes into strongly-typed [`crate::ast`] nodes.
+
 use pest::iterators::Pair;
 use pest::Parser;
 use pest_derive::Parser;
@@ -7,6 +17,7 @@ use strsim::levenshtein;
 use crate::ast::*;
 use crate::error::GustError;
 
+/// The pest-generated PEG parser, driven by `grammar.pest`.
 #[derive(Parser)]
 #[grammar = "grammar.pest"]
 pub struct GustParser;
@@ -15,11 +26,38 @@ thread_local! {
     static PARSE_RECOVERY_ERRORS: RefCell<Vec<String>> = const { RefCell::new(Vec::new()) };
 }
 
-/// Parse a .gu source file into a Program AST
+/// Parse a `.gu` source string into a [`Program`] AST.
+///
+/// Returns the parsed AST on success, or a human-readable error message on
+/// failure. For structured error diagnostics with source locations, use
+/// [`parse_program_with_errors`] instead.
+///
+/// # Examples
+///
+/// ```rust
+/// use gust_lang::parse_program;
+///
+/// let ast = parse_program("machine Foo { state A }").unwrap();
+/// assert_eq!(ast.machines[0].name, "Foo");
+/// ```
+///
+/// # Errors
+///
+/// Returns `Err(String)` when the source does not conform to the Gust
+/// grammar, or when numeric literals are out of range.
 pub fn parse_program(source: &str) -> Result<Program, String> {
     parse_program_inner(source).map_err(|e| format!("Parse error: {e}"))
 }
 
+/// Parse a `.gu` source string, returning a structured [`GustError`] on failure.
+///
+/// This variant includes the file path in the error and attempts to suggest
+/// corrections for misspelled keywords using Levenshtein distance.
+///
+/// # Errors
+///
+/// Returns `Err(GustError)` with file, line, column, and a helpful message
+/// when parsing fails.
 pub fn parse_program_with_errors(source: &str, file: &str) -> Result<Program, GustError> {
     parse_program_inner(source)
         .map_err(|e| to_gust_error(source, file, &format!("Parse error: {e}")))

--- a/gust-lang/src/validator.rs
+++ b/gust-lang/src/validator.rs
@@ -1,20 +1,70 @@
+//! Semantic validator for the Gust AST.
+//!
+//! After parsing, [`validate_program`] walks the AST to check for semantic
+//! errors and emit warnings. Checks include:
+//!
+//! - Duplicate state and transition names within a machine.
+//! - Undefined states referenced in transition sources/targets.
+//! - `goto` argument count matching the target state's field count.
+//! - `goto` targets must be declared targets of the enclosing transition.
+//! - Undeclared effects, channels, and spawn targets.
+//! - `ctx.field` references validated against the from-state's fields.
+//! - Handler return types rejected (not yet supported by codegen).
+//! - Bare `return` statements rejected in handlers.
+//! - Warnings for unreachable states, unhandled transitions, unused effects,
+//!   and handlers that may fall through without a `goto`.
+//!
+//! The validator uses string search on the source text to approximate source
+//! spans for diagnostics (a known limitation). Suggestions for misspelled
+//! names are provided via Levenshtein distance.
+
 use crate::ast::{Block, Expr, Pattern, Program, StateDecl, Statement, TransitionDecl};
 use crate::error::{GustError, GustWarning};
 use std::collections::{HashMap, HashSet};
 use strsim::levenshtein;
 
+/// The result of validating a [`Program`] AST.
+///
+/// Contains accumulated errors (which prevent code generation) and warnings
+/// (which are informational but non-blocking).
 #[derive(Debug, Default, Clone)]
 pub struct ValidationReport {
+    /// Errors that must be fixed before code generation can proceed.
     pub errors: Vec<GustError>,
+    /// Warnings about potential issues (e.g. unreachable states, unused effects).
     pub warnings: Vec<GustWarning>,
 }
 
 impl ValidationReport {
+    /// Returns `true` if no errors were found (warnings are ignored).
     pub fn is_ok(&self) -> bool {
         self.errors.is_empty()
     }
 }
 
+/// Perform semantic validation on a parsed [`Program`] AST.
+///
+/// Checks all machines for structural correctness (see module-level docs for
+/// the full list of checks). Returns a [`ValidationReport`] with any errors
+/// and warnings found.
+///
+/// # Examples
+///
+/// ```rust
+/// use gust_lang::{parse_program, validate_program};
+///
+/// let source = r#"
+///     machine Counter {
+///         state Idle(count: i64)
+///         state Running(count: i64)
+///         transition start: Idle -> Running
+///         on start(ctx: Ctx) { goto Running(0); }
+///     }
+/// "#;
+/// let ast = parse_program(source).unwrap();
+/// let report = validate_program(&ast, "counter.gu", source);
+/// assert!(report.is_ok());
+/// ```
 pub fn validate_program(program: &Program, file: &str, source: &str) -> ValidationReport {
     let mut report = ValidationReport::default();
     let locator = SourceLocator::new(source);


### PR DESCRIPTION
## Summary

Adds `///` doc comments and `//!` module-level documentation to every public type, function, trait, and field in the `gust-lang` crate — the core compiler library.

## Changes

- **`lib.rs`**: Crate-level docs with pipeline overview and working quick-start example
- **`ast.rs`**: 25+ public types documented — `Program`, `MachineDecl`, `StateDecl`, `TransitionDecl`, `Handler`, `Effect`, `Statement`, `Expr`, etc. Each with Gust syntax examples and field-level docs
- **`parser.rs`**: `parse_program` and `parse_program_with_errors` with `# Examples` and `# Errors` sections
- **`validator.rs`**: `validate_program`, `ValidationReport` with catalog of all validation checks
- **`codegen.rs`**: `RustCodegen` with usage example
- **`codegen_go.rs`**: `GoCodegen` with Rust-vs-Go design differences
- **`codegen_wasm.rs`**, **`codegen_nostd.rs`**, **`codegen_ffi.rs`**: Target-specific docs
- **`codegen_common.rs`**: Missing doc on `expr_references_ctx`
- **`format.rs`**: `format_program` and `format_program_preserving` with examples
- **`error.rs`**: `GustError`, `GustWarning` with field-level docs

580 lines of documentation added across 12 files.

## Test Plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --workspace --all-targets --all-features` passes (85+ tests)
- [x] `cargo doc -p gust-lang --no-deps` produces zero warnings

---
Generated by autonomous-work agent