### PR TITLE
feat(validator): add goto field type validation

### DIFF
--- a/gust-lang/src/validator.rs
+++ b/gust-lang/src/validator.rs
@@ -1,4 +1,7 @@
-use crate::ast::{Block, Expr, Pattern, Program, StateDecl, Statement, TransitionDecl};
+use crate::ast::{
+    Block, EffectDecl, Expr, Field, Pattern, Program, StateDecl, Statement, TransitionDecl,
+    TypeDecl, TypeExpr,
+};
 use crate::error::{GustError, GustWarning};
 use std::collections::{HashMap, HashSet};
 use strsim::levenshtein;
@@ -151,6 +154,20 @@ pub fn validate_program(program: &Program, file: &str, source: &str) -> Validati
             .map(|t| (t.name.as_str(), t.targets.as_slice()))
             .collect();
 
+        // Build maps for type inference in goto type validation
+        let effect_map: HashMap<&str, &EffectDecl> = machine
+            .effects
+            .iter()
+            .map(|e| (e.name.as_str(), e))
+            .collect();
+        let type_map: HashMap<&str, &TypeDecl> =
+            program.types.iter().map(|t| (t.name(), t)).collect();
+        let generic_param_set: HashSet<String> = machine
+            .generic_params
+            .iter()
+            .map(|g| g.name.clone())
+            .collect();
+
         let mut used_declared_effects = HashSet::new();
         let mut unknown_effects = Vec::new();
         for handler in &machine.handlers {
@@ -186,6 +203,42 @@ pub fn validate_program(program: &Program, file: &str, source: &str) -> Validati
                 &mut unknown_effects,
             );
             validate_goto_arity(&handler.body, &state_fields, &locator, file, &mut report);
+
+            // Validate goto argument types match target state field types
+            {
+                // Build initial variable scope from handler parameters
+                let mut variables: HashMap<String, TypeExpr> = HashMap::new();
+                for param in &handler.params {
+                    // Skip the special `ctx` parameter — its fields are resolved separately
+                    if param.name != "ctx" {
+                        variables.insert(param.name.clone(), param.ty.clone());
+                    }
+                }
+
+                // Determine the from-state for ctx.field resolution
+                let from_state = machine
+                    .transitions
+                    .iter()
+                    .find(|t| t.name == handler.transition_name)
+                    .and_then(|t| state_fields.get(t.from.as_str()).copied());
+
+                let mut type_ctx = TypeContext {
+                    variables,
+                    effects: &effect_map,
+                    types: &type_map,
+                    from_state,
+                    generic_params: &generic_param_set,
+                };
+
+                validate_goto_types(
+                    &handler.body,
+                    &state_fields,
+                    &mut type_ctx,
+                    &locator,
+                    file,
+                    &mut report,
+                );
+            }
 
             // Validate that goto targets are declared targets of the transition
             if let Some(targets) = transition_targets.get(handler.transition_name.as_str()) {
@@ -774,6 +827,244 @@ fn register_effect(
         used_declared.insert(effect.to_string());
     } else if !unknown.iter().any(|e| e == effect) {
         unknown.push(effect.to_string());
+    }
+}
+
+// === Goto field type validation ===
+
+/// Context for type inference within a handler body.
+struct TypeContext<'a> {
+    /// Variables in scope: handler params + let bindings.
+    variables: HashMap<String, TypeExpr>,
+    /// Effect declarations for resolving `perform` return types.
+    effects: &'a HashMap<&'a str, &'a EffectDecl>,
+    /// Type declarations (structs/enums) for resolving field access.
+    types: &'a HashMap<&'a str, &'a TypeDecl>,
+    /// The from-state for resolving `ctx.field` references.
+    from_state: Option<&'a StateDecl>,
+    /// Generic type parameters from the machine declaration.
+    generic_params: &'a HashSet<String>,
+}
+
+/// Format a `TypeExpr` as a human-readable string for error messages.
+fn format_type_expr(ty: &TypeExpr) -> String {
+    match ty {
+        TypeExpr::Unit => "()".to_string(),
+        TypeExpr::Simple(name) => name.clone(),
+        TypeExpr::Generic(name, params) => {
+            let inner: Vec<String> = params.iter().map(format_type_expr).collect();
+            format!("{}<{}>", name, inner.join(", "))
+        }
+        TypeExpr::Tuple(types) => {
+            let inner: Vec<String> = types.iter().map(format_type_expr).collect();
+            format!("({})", inner.join(", "))
+        }
+    }
+}
+
+/// Check if two types are compatible. Returns `true` when they match OR when
+/// we cannot determine compatibility (conservative — avoids false positives).
+fn types_compatible(
+    expected: &TypeExpr,
+    actual: &TypeExpr,
+    generic_params: &HashSet<String>,
+) -> bool {
+    // If either type is a generic parameter, we can't validate — treat as compatible
+    if is_generic_param(expected, generic_params) || is_generic_param(actual, generic_params) {
+        return true;
+    }
+
+    match (expected, actual) {
+        (TypeExpr::Unit, TypeExpr::Unit) => true,
+        (TypeExpr::Simple(a), TypeExpr::Simple(b)) => a == b,
+        (TypeExpr::Generic(name_a, params_a), TypeExpr::Generic(name_b, params_b)) => {
+            name_a == name_b
+                && params_a.len() == params_b.len()
+                && params_a
+                    .iter()
+                    .zip(params_b.iter())
+                    .all(|(a, b)| types_compatible(a, b, generic_params))
+        }
+        (TypeExpr::Tuple(types_a), TypeExpr::Tuple(types_b)) => {
+            types_a.len() == types_b.len()
+                && types_a
+                    .iter()
+                    .zip(types_b.iter())
+                    .all(|(a, b)| types_compatible(a, b, generic_params))
+        }
+        _ => false,
+    }
+}
+
+/// Returns true if the type expression is (or contains) a generic type parameter.
+fn is_generic_param(ty: &TypeExpr, generic_params: &HashSet<String>) -> bool {
+    match ty {
+        TypeExpr::Simple(name) => generic_params.contains(name),
+        TypeExpr::Generic(name, params) => {
+            generic_params.contains(name)
+                || params.iter().any(|p| is_generic_param(p, generic_params))
+        }
+        TypeExpr::Tuple(types) => types.iter().any(|t| is_generic_param(t, generic_params)),
+        TypeExpr::Unit => false,
+    }
+}
+
+/// Try to infer the type of an expression. Returns `None` when the type cannot
+/// be determined — callers should skip validation in that case.
+fn infer_expr_type(expr: &Expr, ctx: &TypeContext<'_>) -> Option<TypeExpr> {
+    match expr {
+        Expr::IntLit(_) => Some(TypeExpr::Simple("i64".to_string())),
+        Expr::FloatLit(_) => Some(TypeExpr::Simple("f64".to_string())),
+        Expr::StringLit(_) => Some(TypeExpr::Simple("String".to_string())),
+        Expr::BoolLit(_) => Some(TypeExpr::Simple("bool".to_string())),
+        Expr::Ident(name) => ctx.variables.get(name).cloned(),
+        Expr::Path(enum_name, _variant) => Some(TypeExpr::Simple(enum_name.clone())),
+        Expr::Perform(effect_name, _) => ctx
+            .effects
+            .get(effect_name.as_str())
+            .map(|e| e.return_type.clone()),
+        Expr::FieldAccess(base, field) => infer_field_access_type(base, field, ctx),
+        Expr::BinOp(left, op, _right) => {
+            use crate::ast::BinOp::*;
+            match op {
+                Eq | Neq | Lt | Lte | Gt | Gte | And | Or => {
+                    Some(TypeExpr::Simple("bool".to_string()))
+                }
+                Add | Sub | Mul | Div | Mod => infer_expr_type(left, ctx),
+            }
+        }
+        Expr::UnaryOp(op, inner) => {
+            use crate::ast::UnaryOp::*;
+            match op {
+                Not => Some(TypeExpr::Simple("bool".to_string())),
+                Neg => infer_expr_type(inner, ctx),
+            }
+        }
+        // Function calls — we don't know the return type
+        Expr::FnCall(_, _) => None,
+    }
+}
+
+/// Infer the type of a field access expression (e.g., `ctx.order`, `total.cents`,
+/// `ctx.order.id`).
+fn infer_field_access_type(base: &Expr, field: &str, ctx: &TypeContext<'_>) -> Option<TypeExpr> {
+    // Special case: ctx.field → look up field in from-state
+    if let Expr::Ident(name) = base {
+        if name == "ctx" {
+            return ctx
+                .from_state
+                .and_then(|s| find_field_type(&s.fields, field));
+        }
+    }
+
+    // General case: infer the base type, then look up the field in type declarations
+    let base_type = infer_expr_type(base, ctx)?;
+    resolve_field_type(&base_type, field, ctx.types)
+}
+
+/// Find a field's type in a list of fields.
+fn find_field_type(fields: &[Field], field_name: &str) -> Option<TypeExpr> {
+    fields
+        .iter()
+        .find(|f| f.name == field_name)
+        .map(|f| f.ty.clone())
+}
+
+/// Given a resolved type and a field name, look up the field's type in type declarations.
+fn resolve_field_type(
+    base_type: &TypeExpr,
+    field_name: &str,
+    types: &HashMap<&str, &TypeDecl>,
+) -> Option<TypeExpr> {
+    if let TypeExpr::Simple(type_name) = base_type {
+        if let Some(type_decl) = types.get(type_name.as_str()) {
+            return find_field_type(type_decl.fields(), field_name);
+        }
+    }
+    None
+}
+
+/// Validate that goto argument types match target state field types within a block.
+/// Tracks let bindings as it walks statements sequentially.
+fn validate_goto_types(
+    block: &Block,
+    states: &HashMap<&str, &StateDecl>,
+    ctx: &mut TypeContext<'_>,
+    locator: &SourceLocator<'_>,
+    file: &str,
+    report: &mut ValidationReport,
+) {
+    for stmt in &block.statements {
+        match stmt {
+            Statement::Let { name, ty, value } => {
+                // Determine the type of this binding: explicit annotation or inferred from value
+                let binding_type = if let Some(annotated) = ty {
+                    Some(annotated.clone())
+                } else {
+                    infer_expr_type(value, ctx)
+                };
+                if let Some(resolved_type) = binding_type {
+                    ctx.variables.insert(name.clone(), resolved_type);
+                }
+            }
+            Statement::Goto { state, args } => {
+                if let Some(target) = states.get(state.as_str()) {
+                    // Only check types when arity already matches (arity is checked elsewhere)
+                    if target.fields.len() == args.len() {
+                        for (i, (field, arg)) in target.fields.iter().zip(args.iter()).enumerate() {
+                            if let Some(arg_type) = infer_expr_type(arg, ctx) {
+                                if !types_compatible(&field.ty, &arg_type, ctx.generic_params) {
+                                    let (line, col) = locator.find_goto(state);
+                                    report.errors.push(GustError {
+                                        file: file.to_string(),
+                                        line,
+                                        col,
+                                        message: format!(
+                                            "goto '{}' argument {} has type {}, but field '{}' expects {}",
+                                            state,
+                                            i + 1,
+                                            format_type_expr(&arg_type),
+                                            field.name,
+                                            format_type_expr(&field.ty),
+                                        ),
+                                        note: Some(
+                                            "argument types must match target state field types"
+                                                .to_string(),
+                                        ),
+                                        help: None,
+                                    });
+                                }
+                            }
+                            // If arg_type is None, skip — we can't determine the type
+                        }
+                    }
+                }
+            }
+            Statement::If {
+                then_block,
+                else_block,
+                ..
+            } => {
+                // Clone variables for child scopes — bindings inside branches
+                // don't leak to sibling branches or parent scope
+                let saved = ctx.variables.clone();
+                validate_goto_types(then_block, states, ctx, locator, file, report);
+                ctx.variables = saved.clone();
+                if let Some(else_block) = else_block {
+                    validate_goto_types(else_block, states, ctx, locator, file, report);
+                }
+                ctx.variables = saved;
+            }
+            Statement::Match { arms, .. } => {
+                let saved = ctx.variables.clone();
+                for arm in arms {
+                    ctx.variables = saved.clone();
+                    validate_goto_types(&arm.body, states, ctx, locator, file, report);
+                }
+                ctx.variables = saved;
+            }
+            _ => {}
+        }
     }
 }
 

--- a/gust-lang/tests/diagnostics_validation.rs
+++ b/gust-lang/tests/diagnostics_validation.rs
@@ -462,3 +462,545 @@ machine Demo {
         report.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
     );
 }
+
+// === Goto field type validation tests ===
+
+#[test]
+fn validator_allows_goto_with_matching_types() {
+    let source = r#"
+type Order {
+    id: String,
+    items: Vec<String>,
+}
+machine Processor {
+    state Pending(order: Order)
+    state Running(order: Order, count: i64, label: String)
+
+    transition start: Pending -> Running
+
+    on start() {
+        goto Running(ctx.order, 42, "started");
+    }
+}
+"#;
+    let program = parse_program_with_errors(source, "test.gu").expect("should parse");
+    let report = validate_program(&program, "test.gu", source);
+
+    assert!(
+        !report
+            .errors
+            .iter()
+            .any(|e| e.message.contains("argument") && e.message.contains("has type")),
+        "should not report type errors for matching types, got errors: {:?}",
+        report.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn validator_rejects_goto_with_mismatched_string_vs_int() {
+    let source = r#"
+machine Counter {
+    state Idle
+    state Running(count: i64)
+
+    transition start: Idle -> Running
+
+    on start() {
+        goto Running("not a number");
+    }
+}
+"#;
+    let program = parse_program_with_errors(source, "test.gu").expect("should parse");
+    let report = validate_program(&program, "test.gu", source);
+
+    assert!(
+        report.errors.iter().any(|e| e
+            .message
+            .contains("goto 'Running' argument 1 has type String, but field 'count' expects i64")),
+        "should report type mismatch String vs i64, got errors: {:?}",
+        report.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn validator_rejects_goto_with_mismatched_int_vs_string() {
+    let source = r#"
+machine Namer {
+    state Idle
+    state Named(name: String)
+
+    transition name_it: Idle -> Named
+
+    on name_it() {
+        goto Named(42);
+    }
+}
+"#;
+    let program = parse_program_with_errors(source, "test.gu").expect("should parse");
+    let report = validate_program(&program, "test.gu", source);
+
+    assert!(
+        report.errors.iter().any(|e| e
+            .message
+            .contains("goto 'Named' argument 1 has type i64, but field 'name' expects String")),
+        "should report type mismatch i64 vs String, got errors: {:?}",
+        report.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn validator_rejects_goto_with_mismatched_bool_vs_string() {
+    let source = r#"
+machine Demo {
+    state Idle
+    state Done(result: String)
+
+    transition finish: Idle -> Done
+
+    on finish() {
+        goto Done(true);
+    }
+}
+"#;
+    let program = parse_program_with_errors(source, "test.gu").expect("should parse");
+    let report = validate_program(&program, "test.gu", source);
+
+    assert!(
+        report.errors.iter().any(|e| e
+            .message
+            .contains("goto 'Done' argument 1 has type bool, but field 'result' expects String")),
+        "should report type mismatch bool vs String, got errors: {:?}",
+        report.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn validator_checks_perform_result_type_in_goto() {
+    let source = r#"
+type Money {
+    cents: i64,
+}
+machine Processor {
+    state Pending
+    state Done(total: Money)
+
+    transition process: Pending -> Done
+
+    effect calculate() -> String
+
+    on process() {
+        let result = perform calculate();
+        goto Done(result);
+    }
+}
+"#;
+    let program = parse_program_with_errors(source, "test.gu").expect("should parse");
+    let report = validate_program(&program, "test.gu", source);
+
+    assert!(
+        report.errors.iter().any(|e| e
+            .message
+            .contains("goto 'Done' argument 1 has type String, but field 'total' expects Money")),
+        "should detect type mismatch from perform result, got errors: {:?}",
+        report.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn validator_allows_perform_result_with_correct_type() {
+    let source = r#"
+type Money {
+    cents: i64,
+}
+machine Processor {
+    state Pending
+    state Done(total: Money)
+
+    transition process: Pending -> Done
+
+    effect calculate() -> Money
+
+    on process() {
+        let result = perform calculate();
+        goto Done(result);
+    }
+}
+"#;
+    let program = parse_program_with_errors(source, "test.gu").expect("should parse");
+    let report = validate_program(&program, "test.gu", source);
+
+    assert!(
+        !report
+            .errors
+            .iter()
+            .any(|e| e.message.contains("argument") && e.message.contains("has type")),
+        "should not report type errors when perform returns correct type, got errors: {:?}",
+        report.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn validator_checks_handler_param_types_in_goto() {
+    let source = r#"
+machine Pipeline {
+    state Idle
+    state Running(count: i64)
+
+    transition start: Idle -> Running
+
+    on start(name: String) {
+        goto Running(name);
+    }
+}
+"#;
+    let program = parse_program_with_errors(source, "test.gu").expect("should parse");
+    let report = validate_program(&program, "test.gu", source);
+
+    assert!(
+        report.errors.iter().any(|e| e
+            .message
+            .contains("goto 'Running' argument 1 has type String, but field 'count' expects i64")),
+        "should detect handler param type mismatch, got errors: {:?}",
+        report.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn validator_checks_types_in_nested_if_blocks() {
+    let source = r#"
+machine Pipeline {
+    state Pending
+    state Done(count: i64)
+    state Failed(reason: String)
+
+    transition finish: Pending -> Done | Failed
+
+    on finish() {
+        if true {
+            goto Done("wrong type");
+        } else {
+            goto Failed(42);
+        }
+    }
+}
+"#;
+    let program = parse_program_with_errors(source, "test.gu").expect("should parse");
+    let report = validate_program(&program, "test.gu", source);
+
+    assert!(
+        report.errors.iter().any(|e| e
+            .message
+            .contains("goto 'Done' argument 1 has type String, but field 'count' expects i64")),
+        "should detect type mismatch in if-branch, got errors: {:?}",
+        report.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+    assert!(
+        report.errors.iter().any(|e| e
+            .message
+            .contains("goto 'Failed' argument 1 has type i64, but field 'reason' expects String")),
+        "should detect type mismatch in else-branch, got errors: {:?}",
+        report.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn validator_skips_check_for_unknown_types() {
+    // FnCall return type is unknown — validator should NOT emit false positive
+    let source = r#"
+machine Pipeline {
+    state Idle
+    state Done(result: String)
+
+    transition finish: Idle -> Done
+
+    on finish() {
+        let x = some_function();
+        goto Done(x);
+    }
+}
+"#;
+    let program = parse_program_with_errors(source, "test.gu").expect("should parse");
+    let report = validate_program(&program, "test.gu", source);
+
+    // The function call result type is unknown — no type error should be emitted
+    assert!(
+        !report
+            .errors
+            .iter()
+            .any(|e| e.message.contains("argument") && e.message.contains("has type")),
+        "should not report type errors for unknown expression types, got errors: {:?}",
+        report.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn validator_checks_ctx_field_type_in_goto() {
+    let source = r#"
+type Order {
+    id: String,
+}
+machine Processor {
+    state Pending(order: Order)
+    state Done(count: i64)
+
+    transition finish: Pending -> Done
+
+    on finish() {
+        goto Done(ctx.order);
+    }
+}
+"#;
+    let program = parse_program_with_errors(source, "test.gu").expect("should parse");
+    let report = validate_program(&program, "test.gu", source);
+
+    assert!(
+        report.errors.iter().any(|e| e
+            .message
+            .contains("goto 'Done' argument 1 has type Order, but field 'count' expects i64")),
+        "should detect ctx.field type mismatch, got errors: {:?}",
+        report.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn validator_checks_nested_field_access_type_in_goto() {
+    let source = r#"
+type Order {
+    id: String,
+    count: i64,
+}
+machine Processor {
+    state Pending(order: Order)
+    state Done(label: String)
+
+    transition finish: Pending -> Done
+
+    on finish() {
+        goto Done(ctx.order.count);
+    }
+}
+"#;
+    let program = parse_program_with_errors(source, "test.gu").expect("should parse");
+    let report = validate_program(&program, "test.gu", source);
+
+    assert!(
+        report.errors.iter().any(|e| e
+            .message
+            .contains("goto 'Done' argument 1 has type i64, but field 'label' expects String")),
+        "should detect nested field access type mismatch, got errors: {:?}",
+        report.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn validator_allows_correct_nested_field_access_in_goto() {
+    let source = r#"
+type Order {
+    id: String,
+    count: i64,
+}
+machine Processor {
+    state Pending(order: Order)
+    state Done(id: String)
+
+    transition finish: Pending -> Done
+
+    on finish() {
+        goto Done(ctx.order.id);
+    }
+}
+"#;
+    let program = parse_program_with_errors(source, "test.gu").expect("should parse");
+    let report = validate_program(&program, "test.gu", source);
+
+    assert!(
+        !report
+            .errors
+            .iter()
+            .any(|e| e.message.contains("argument") && e.message.contains("has type")),
+        "should not report type errors for correct nested field access, got errors: {:?}",
+        report.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn validator_checks_let_binding_with_explicit_type() {
+    let source = r#"
+machine Pipeline {
+    state Idle
+    state Done(name: String)
+
+    transition finish: Idle -> Done
+
+    on finish() {
+        let count: i64 = 42;
+        goto Done(count);
+    }
+}
+"#;
+    let program = parse_program_with_errors(source, "test.gu").expect("should parse");
+    let report = validate_program(&program, "test.gu", source);
+
+    assert!(
+        report.errors.iter().any(|e| e
+            .message
+            .contains("goto 'Done' argument 1 has type i64, but field 'name' expects String")),
+        "should detect explicit-typed let binding mismatch, got errors: {:?}",
+        report.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn validator_checks_enum_path_type_in_goto() {
+    let source = r#"
+enum Status {
+    Pending,
+    Done(String),
+}
+machine Tracker {
+    state Idle
+    state Active(count: i64)
+
+    transition start: Idle -> Active
+
+    on start() {
+        goto Active(Status::Pending);
+    }
+}
+"#;
+    let program = parse_program_with_errors(source, "test.gu").expect("should parse");
+    let report = validate_program(&program, "test.gu", source);
+
+    assert!(
+        report.errors.iter().any(|e| e
+            .message
+            .contains("goto 'Active' argument 1 has type Status, but field 'count' expects i64")),
+        "should detect enum path type mismatch, got errors: {:?}",
+        report.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn validator_allows_enum_path_with_correct_type() {
+    let source = r#"
+enum Status {
+    Pending,
+    Done(String),
+}
+machine Tracker {
+    state Idle
+    state Active(status: Status)
+
+    transition start: Idle -> Active
+
+    on start() {
+        goto Active(Status::Pending);
+    }
+}
+"#;
+    let program = parse_program_with_errors(source, "test.gu").expect("should parse");
+    let report = validate_program(&program, "test.gu", source);
+
+    assert!(
+        !report
+            .errors
+            .iter()
+            .any(|e| e.message.contains("argument") && e.message.contains("has type")),
+        "should not report type errors for correct enum path, got errors: {:?}",
+        report.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn validator_checks_multiple_mismatched_args() {
+    let source = r#"
+machine Demo {
+    state Idle
+    state Done(name: String, count: i64, flag: bool)
+
+    transition finish: Idle -> Done
+
+    on finish() {
+        goto Done(42, "wrong", "not bool");
+    }
+}
+"#;
+    let program = parse_program_with_errors(source, "test.gu").expect("should parse");
+    let report = validate_program(&program, "test.gu", source);
+
+    let type_errors: Vec<&String> = report
+        .errors
+        .iter()
+        .filter(|e| e.message.contains("argument") && e.message.contains("has type"))
+        .map(|e| &e.message)
+        .collect();
+
+    assert!(
+        type_errors.len() >= 3,
+        "should report all three type mismatches, got {} type errors: {:?}",
+        type_errors.len(),
+        type_errors
+    );
+}
+
+#[test]
+fn validator_checks_comparison_op_produces_bool() {
+    let source = r#"
+machine Demo {
+    state Idle
+    state Done(name: String)
+
+    transition finish: Idle -> Done
+
+    on finish() {
+        goto Done(1 > 2);
+    }
+}
+"#;
+    let program = parse_program_with_errors(source, "test.gu").expect("should parse");
+    let report = validate_program(&program, "test.gu", source);
+
+    assert!(
+        report.errors.iter().any(|e| e
+            .message
+            .contains("goto 'Done' argument 1 has type bool, but field 'name' expects String")),
+        "should detect comparison op produces bool, got errors: {:?}",
+        report.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn validator_does_not_type_check_when_arity_mismatches() {
+    // When arity already mismatches, don't also emit type errors
+    let source = r#"
+machine Demo {
+    state Idle
+    state Done(name: String, count: i64)
+
+    transition finish: Idle -> Done
+
+    on finish() {
+        goto Done("only one arg");
+    }
+}
+"#;
+    let program = parse_program_with_errors(source, "test.gu").expect("should parse");
+    let report = validate_program(&program, "test.gu", source);
+
+    // Should have arity error but no type error
+    assert!(
+        report
+            .errors
+            .iter()
+            .any(|e| e.message.contains("expects 2 argument(s) but got 1")),
+        "should report arity error"
+    );
+    assert!(
+        !report
+            .errors
+            .iter()
+            .any(|e| e.message.contains("has type") && e.message.contains("but field")),
+        "should not report type errors when arity mismatches, got errors: {:?}",
+        report.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
## Summary

Adds type checking for `goto` statement arguments against target state field types, partially addressing issue #30 and roadmap Priority 1. The validator now reports mismatched types with helpful error messages while being conservative — unknown types do not produce false positives.

## Changes

- **`gust-lang/src/validator.rs`**: Added type inference and validation:
  - `TypeContext` for tracking variables in scope (handler params, let bindings)
  - `infer_expr_type()` — infers types for literals, identifiers, field access, perform expressions, enum paths, binary/unary ops
  - `types_compatible()` — structural comparison with generic parameter handling
  - `validate_goto_types()` — walks handler blocks, tracks let binding scopes, validates goto args vs state fields
  - Conservatively skips checks when type cannot be inferred (no false positives)
- **`gust-lang/tests/diagnostics_validation.rs`**: 18 new tests covering:
  - Matching types pass validation
  - String/i64/bool mismatches detected
  - Perform return types checked
  - Nested field access resolution
  - Let binding type annotations
  - Enum path typing
  - Arity mismatch suppresses type errors (no double-reporting)
  - Unknown types don't produce false positives

## Design Decisions

- **Conservative**: if type can't be inferred, the check is skipped rather than emitting a false positive
- **Scoped**: let bindings are properly scoped through if/else/match branches
- **Composable**: `TypeContext` is extensible for future type checking passes (effect arg types, binary expression types, etc.)

## Test Plan

- [x] All 77 workspace tests pass (59 existing + 18 new)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

Partially addresses #30

---
Generated by autonomous-work agent