### PR TITLE
fix(validator): satisfy clippy 1.95 collapsible_match

### DIFF
--- a/gust-lang/src/codegen_common.rs
+++ b/gust-lang/src/codegen_common.rs
@@ -230,10 +230,8 @@ fn collect_idents_stmt(stmt: &Statement, ctx_param: Option<&str>, set: &mut Hash
 
 fn collect_idents_expr(expr: &Expr, ctx_param: Option<&str>, set: &mut HashSet<String>) {
     match expr {
-        Expr::Ident(name) => {
-            if ctx_param.is_none_or(|ctx| name != ctx) {
-                set.insert(name.clone());
-            }
+        Expr::Ident(name) if ctx_param.is_none_or(|ctx| name != ctx) => {
+            set.insert(name.clone());
         }
         Expr::FieldAccess(base, _field) => {
             if let Some(ctx) = ctx_param {

--- a/gust-lang/src/validator.rs
+++ b/gust-lang/src/validator.rs
@@ -366,9 +366,7 @@ fn validate_goto_targets(
 ) {
     for stmt in &block.statements {
         match stmt {
-            Statement::Goto { state, span, .. }
-                if !valid_targets.iter().any(|t| t == state) =>
-            {
+            Statement::Goto { state, span, .. } if !valid_targets.iter().any(|t| t == state) => {
                 let targets_list = valid_targets.join(", ");
                 report.errors.push(GustError {
                     file: file.to_string(),

--- a/gust-lang/src/validator.rs
+++ b/gust-lang/src/validator.rs
@@ -366,24 +366,24 @@ fn validate_goto_targets(
 ) {
     for stmt in &block.statements {
         match stmt {
-            Statement::Goto { state, span, .. } => {
-                if !valid_targets.iter().any(|t| t == state) {
-                    let targets_list = valid_targets.join(", ");
-                    report.errors.push(GustError {
-                        file: file.to_string(),
-                        line: span.start_line,
-                        col: span.start_col,
-                        message: format!(
-                            "goto target '{}' is not a declared target of transition '{}'; valid targets are: {}",
-                            state, transition_name, targets_list
-                        ),
-                        note: Some(format!(
-                            "transition '{}' can only go to: {}",
-                            transition_name, targets_list
-                        )),
-                        help: suggest_name(state, valid_targets),
-                    });
-                }
+            Statement::Goto { state, span, .. }
+                if !valid_targets.iter().any(|t| t == state) =>
+            {
+                let targets_list = valid_targets.join(", ");
+                report.errors.push(GustError {
+                    file: file.to_string(),
+                    line: span.start_line,
+                    col: span.start_col,
+                    message: format!(
+                        "goto target '{}' is not a declared target of transition '{}'; valid targets are: {}",
+                        state, transition_name, targets_list
+                    ),
+                    note: Some(format!(
+                        "transition '{}' can only go to: {}",
+                        transition_name, targets_list
+                    )),
+                    help: suggest_name(state, valid_targets),
+                });
             }
             Statement::If {
                 then_block,
@@ -502,19 +502,15 @@ fn validate_send_targets(
 ) {
     for stmt in &block.statements {
         match stmt {
-            Statement::Send { channel, span, .. } => {
-                if !channels.contains(channel) {
-                    report.errors.push(GustError {
-                        file: file.to_string(),
-                        line: span.start_line,
-                        col: span.start_col,
-                        message: format!("undeclared channel '{}'", channel),
-                        note: Some(
-                            "channel is used but never declared in this program".to_string(),
-                        ),
-                        help: suggest_name(channel, channel_names),
-                    });
-                }
+            Statement::Send { channel, span, .. } if !channels.contains(channel) => {
+                report.errors.push(GustError {
+                    file: file.to_string(),
+                    line: span.start_line,
+                    col: span.start_col,
+                    message: format!("undeclared channel '{}'", channel),
+                    note: Some("channel is used but never declared in this program".to_string()),
+                    help: suggest_name(channel, channel_names),
+                });
             }
             Statement::If {
                 then_block,
@@ -545,17 +541,15 @@ fn validate_spawn_targets(
 ) {
     for stmt in &block.statements {
         match stmt {
-            Statement::Spawn { machine, span, .. } => {
-                if !machines.contains(machine) {
-                    report.errors.push(GustError {
-                        file: file.to_string(),
-                        line: span.start_line,
-                        col: span.start_col,
-                        message: format!("undeclared machine '{}'", machine),
-                        note: Some("spawn target must be a declared machine".to_string()),
-                        help: suggest_name(machine, machine_names),
-                    });
-                }
+            Statement::Spawn { machine, span, .. } if !machines.contains(machine) => {
+                report.errors.push(GustError {
+                    file: file.to_string(),
+                    line: span.start_line,
+                    col: span.start_col,
+                    message: format!("undeclared machine '{}'", machine),
+                    note: Some("spawn target must be a declared machine".to_string()),
+                    help: suggest_name(machine, machine_names),
+                });
             }
             Statement::If {
                 then_block,


### PR DESCRIPTION
## Summary

CI started failing after Rust toolchain updated to 1.95, which introduced/strengthened the `collapsible_match` clippy lint. The `Statement::Send` and `Statement::Spawn` match arms in `validator.rs` contained `if !channels.contains(...)` / `if !machines.contains(...)` checks that trip the new lint.

## Fix

Lift those `if` checks into match-arm guards so both arms stay shape-matched while clippy is happy.

## Test plan

- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] `cargo fmt --all -- --check` passes

---
Generated with [Claude Code](https://claude.ai/code)