### PR TITLE
feat(validator): add effect argument arity validation

### DIFF
--- a/gust-lang/src/validator.rs
+++ b/gust-lang/src/validator.rs
@@ -1,4 +1,6 @@
-use crate::ast::{Block, Expr, Pattern, Program, Span, StateDecl, Statement, TransitionDecl};
+use crate::ast::{
+    Block, Expr, Field, Pattern, Program, Span, StateDecl, Statement, TransitionDecl,
+};
 use crate::error::{GustError, GustWarning};
 use std::collections::{HashMap, HashSet};
 use strsim::levenshtein;
@@ -36,6 +38,11 @@ pub fn validate_program(program: &Program, file: &str, _source: &str) -> Validat
             .states
             .iter()
             .map(|s| (s.name.as_str(), s))
+            .collect();
+        let effect_params: HashMap<&str, &[Field]> = machine
+            .effects
+            .iter()
+            .map(|e| (e.name.as_str(), e.params.as_slice()))
             .collect();
 
         let mut seen_states = HashSet::new();
@@ -189,6 +196,7 @@ pub fn validate_program(program: &Program, file: &str, _source: &str) -> Validat
                 &mut unknown_effects,
             );
             validate_goto_arity(&handler.body, &state_fields, file, &mut report);
+            validate_perform_arity(&handler.body, &effect_params, file, &mut report);
 
             // Validate that goto targets are declared targets of the transition
             if let Some(targets) = transition_targets.get(handler.transition_name.as_str()) {
@@ -354,6 +362,98 @@ fn validate_goto_arity(
             }
             _ => {}
         }
+    }
+}
+
+fn validate_perform_arity(
+    block: &Block,
+    effects: &HashMap<&str, &[Field]>,
+    file: &str,
+    report: &mut ValidationReport,
+) {
+    for stmt in &block.statements {
+        match stmt {
+            Statement::Perform { effect, args, span } => {
+                check_perform_args(effect, args, *span, effects, file, report);
+            }
+            Statement::Let { value, .. } | Statement::Expr(value) | Statement::Return(value) => {
+                check_expr_perform_arity(value, effects, file, report);
+            }
+            Statement::If {
+                then_block,
+                else_block,
+                ..
+            } => {
+                validate_perform_arity(then_block, effects, file, report);
+                if let Some(else_block) = else_block {
+                    validate_perform_arity(else_block, effects, file, report);
+                }
+            }
+            Statement::Match { arms, .. } => {
+                for arm in arms {
+                    validate_perform_arity(&arm.body, effects, file, report);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn check_perform_args(
+    effect: &str,
+    args: &[Expr],
+    span: Span,
+    effects: &HashMap<&str, &[Field]>,
+    file: &str,
+    report: &mut ValidationReport,
+) {
+    if let Some(params) = effects.get(effect) {
+        if params.len() != args.len() {
+            report.errors.push(GustError {
+                file: file.to_string(),
+                line: span.start_line,
+                col: span.start_col,
+                message: format!(
+                    "effect '{}' expects {} argument(s) but got {}",
+                    effect,
+                    params.len(),
+                    args.len()
+                ),
+                note: Some("perform argument count must match effect parameter count".to_string()),
+                help: None,
+            });
+        }
+    }
+    // Unknown effects are already reported by collect_effects_from_block - skip here.
+}
+
+fn check_expr_perform_arity(
+    expr: &Expr,
+    effects: &HashMap<&str, &[Field]>,
+    file: &str,
+    report: &mut ValidationReport,
+) {
+    match expr {
+        Expr::Perform(effect, args) => {
+            // Expr::Perform has no span; fall back to default span at call site.
+            check_perform_args(effect, args, Span::default(), effects, file, report);
+        }
+        Expr::BinOp(left, _, right) => {
+            check_expr_perform_arity(left, effects, file, report);
+            check_expr_perform_arity(right, effects, file, report);
+        }
+        Expr::UnaryOp(_, inner) => {
+            check_expr_perform_arity(inner, effects, file, report);
+        }
+        Expr::FieldAccess(base, _) => {
+            check_expr_perform_arity(base, effects, file, report);
+        }
+        Expr::FnCall(_, args) => {
+            for arg in args {
+                check_expr_perform_arity(arg, effects, file, report);
+            }
+        }
+        _ => {}
     }
 }
 

--- a/gust-lang/tests/diagnostics_validation.rs
+++ b/gust-lang/tests/diagnostics_validation.rs
@@ -462,3 +462,187 @@ machine Demo {
         report.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
     );
 }
+
+// === Effect argument arity validation tests ===
+
+#[test]
+fn validator_allows_correct_effect_arity() {
+    let source = r#"
+machine Fetcher {
+    state Start
+    state Done(result: String)
+
+    transition run: Start -> Done
+
+    effect fetch_data(url: String, timeout: i64) -> String
+
+    on run() {
+        let result = perform fetch_data("example", 30);
+        goto Done(result);
+    }
+}
+"#;
+    let program = parse_program_with_errors(source, "test.gu").expect("should parse");
+    let report = validate_program(&program, "test.gu", source);
+
+    assert!(
+        !report
+            .errors
+            .iter()
+            .any(|e| e.message.contains("effect 'fetch_data' expects")),
+        "should not report arity error for correct args, got errors: {:?}",
+        report.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn validator_reports_too_few_effect_args() {
+    let source = r#"
+machine Fetcher {
+    state Start
+    state Done(result: String)
+
+    transition run: Start -> Done
+
+    effect fetch_data(url: String, timeout: i64) -> String
+
+    on run() {
+        let result = perform fetch_data("example");
+        goto Done(result);
+    }
+}
+"#;
+    let program = parse_program_with_errors(source, "test.gu").expect("should parse");
+    let report = validate_program(&program, "test.gu", source);
+
+    assert!(
+        report.errors.iter().any(|e| e
+            .message
+            .contains("effect 'fetch_data' expects 2 argument(s) but got 1")),
+        "should report too few args, got errors: {:?}",
+        report.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn validator_reports_too_many_effect_args() {
+    let source = r#"
+machine Fetcher {
+    state Start
+    state Done(result: String)
+
+    transition run: Start -> Done
+
+    effect fetch_data(url: String) -> String
+
+    on run() {
+        let result = perform fetch_data("example", 30, true);
+        goto Done(result);
+    }
+}
+"#;
+    let program = parse_program_with_errors(source, "test.gu").expect("should parse");
+    let report = validate_program(&program, "test.gu", source);
+
+    assert!(
+        report.errors.iter().any(|e| e
+            .message
+            .contains("effect 'fetch_data' expects 1 argument(s) but got 3")),
+        "should report too many args, got errors: {:?}",
+        report.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn validator_reports_args_on_zero_param_effect() {
+    let source = r#"
+machine Pinger {
+    state Start
+    state Done(ok: bool)
+
+    transition ping: Start -> Done
+
+    effect ping_server() -> bool
+
+    on ping() {
+        let ok = perform ping_server("extra_arg");
+        goto Done(ok);
+    }
+}
+"#;
+    let program = parse_program_with_errors(source, "test.gu").expect("should parse");
+    let report = validate_program(&program, "test.gu", source);
+
+    assert!(
+        report.errors.iter().any(|e| e
+            .message
+            .contains("effect 'ping_server' expects 0 argument(s) but got 1")),
+        "should report args on zero-param effect, got errors: {:?}",
+        report.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn validator_checks_perform_as_expression_in_let() {
+    let source = r#"
+machine Worker {
+    state Idle
+    state Working(data: String)
+
+    transition start: Idle -> Working
+
+    effect load(key: String, ns: String) -> String
+
+    on start() {
+        let data = perform load("mykey");
+        goto Working(data);
+    }
+}
+"#;
+    let program = parse_program_with_errors(source, "test.gu").expect("should parse");
+    let report = validate_program(&program, "test.gu", source);
+
+    assert!(
+        report.errors.iter().any(|e| e
+            .message
+            .contains("effect 'load' expects 2 argument(s) but got 1")),
+        "should check perform-as-expression arity, got errors: {:?}",
+        report.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn validator_does_not_report_arity_for_unknown_effects() {
+    let source = r#"
+machine Worker {
+    state Idle
+    state Done
+
+    transition go: Idle -> Done
+
+    on go() {
+        perform unknown_effect("a", "b", "c");
+        goto Done();
+    }
+}
+"#;
+    let program = parse_program_with_errors(source, "test.gu").expect("should parse");
+    let report = validate_program(&program, "test.gu", source);
+
+    // Should report "undeclared effect" but NOT an arity mismatch
+    assert!(
+        report
+            .errors
+            .iter()
+            .any(|e| e.message.contains("undeclared effect 'unknown_effect'")),
+        "should report undeclared effect"
+    );
+    assert!(
+        !report
+            .errors
+            .iter()
+            .any(|e| e.message.contains("expects") && e.message.contains("argument(s) but got")),
+        "should not report arity error for unknown effect, got errors: {:?}",
+        report.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
## Summary

Rebased version of #34 on top of current master (which now has source span tracking from #13 and the clippy 1.95 fixes from #41).

Validates that `perform` invocations pass the correct number of arguments matching the effect's declared parameter count.

## Changes

- `gust-lang/src/validator.rs` — `validate_perform_arity` + `check_perform_args` + `check_expr_perform_arity`
- `gust-lang/tests/diagnostics_validation.rs` — 6 new tests (correct arity / too few / too many / zero-param / perform-in-let / unknown-effect skipped)

## Differences from original #34

- Uses `Statement::Perform.span` directly instead of the removed `SourceLocator::find_perform`
- `Expr::Perform` does not carry a span in the current AST, so nested-expression arity violations fall back to `Span::default()` until expression spans land

## Test Plan

- [x] `cargo test -p gust-lang` — all tests pass (24 diagnostics, +6 new)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`

Closes #34.

---
Generated with [Claude Code](https://claude.ai/code)