### PR TITLE
feat(validator): finish handler type checking (items 2-4 of #30)

### DIFF
--- a/gust-lang/src/validator.rs
+++ b/gust-lang/src/validator.rs
@@ -257,7 +257,27 @@ pub fn validate_program(program: &Program, file: &str, _source: &str) -> Validat
                     file,
                     &mut report,
                 );
+                // Extra expression-level type checks (perform-let annotations,
+                // binary op operand compatibility). Uses its own variables scope so
+                // goto type validation (above) is unaffected by ordering.
+                let mut expr_ctx = TypeContext {
+                    variables: type_ctx.variables.clone(),
+                    effects: type_ctx.effects,
+                    types: type_ctx.types,
+                    from_state: type_ctx.from_state,
+                    generic_params: type_ctx.generic_params,
+                };
+                validate_expression_types(&handler.body, &mut expr_ctx, file, &mut report);
             }
+
+            // Warn when if/else branches have inconsistent termination.
+            check_if_branch_consistency(
+                &handler.body,
+                &handler.transition_name,
+                &enum_variants,
+                file,
+                &mut report,
+            );
 
             // Validate that goto targets are declared targets of the transition
             if let Some(targets) = transition_targets.get(handler.transition_name.as_str()) {
@@ -1280,6 +1300,249 @@ fn validate_goto_types(
                     validate_goto_types(&arm.body, states, ctx, file, report);
                 }
                 ctx.variables = saved;
+            }
+            _ => {}
+        }
+    }
+}
+
+// === Handler expression type checking (issue #30 items 2 and 4) ===
+
+/// Walks handler statements and checks:
+/// - **Item 2**: `let x: T = perform e(...)` — annotated `T` must match the effect's return type.
+/// - **Item 4**: binary operator operand types — both sides must be type-compatible.
+///
+/// Tracks let bindings with the same scoping rules as `validate_goto_types`
+/// (branches get an isolated scope copy).
+fn validate_expression_types(
+    block: &Block,
+    ctx: &mut TypeContext<'_>,
+    file: &str,
+    report: &mut ValidationReport,
+) {
+    for stmt in &block.statements {
+        match stmt {
+            Statement::Let { name, ty, value } => {
+                // Item 2: explicitly annotated let with a perform RHS must agree with the effect's return type.
+                if let (Some(annotated), Expr::Perform(effect_name, _)) = (ty, value) {
+                    if let Some(effect) = ctx.effects.get(effect_name.as_str()) {
+                        if !types_compatible(annotated, &effect.return_type, ctx.generic_params) {
+                            report.errors.push(GustError {
+                                file: file.to_string(),
+                                line: effect.span.start_line,
+                                col: effect.span.start_col,
+                                message: format!(
+                                    "let '{}' annotated as {}, but effect '{}' returns {}",
+                                    name,
+                                    format_type_expr(annotated),
+                                    effect_name,
+                                    format_type_expr(&effect.return_type),
+                                ),
+                                note: Some(
+                                    "let-binding annotation must match the effect's declared return type"
+                                        .to_string(),
+                                ),
+                                help: None,
+                            });
+                        }
+                    }
+                }
+
+                // Item 4: walk the RHS for binop operand mismatches.
+                check_binop_types_in_expr(value, ctx, file, report);
+
+                // Update scope with the binding's inferred or annotated type.
+                let binding_type = if let Some(annotated) = ty {
+                    Some(annotated.clone())
+                } else {
+                    infer_expr_type(value, ctx)
+                };
+                if let Some(resolved_type) = binding_type {
+                    ctx.variables.insert(name.clone(), resolved_type);
+                }
+            }
+            Statement::Goto { args, .. } => {
+                for arg in args {
+                    check_binop_types_in_expr(arg, ctx, file, report);
+                }
+            }
+            Statement::Perform { args, .. } => {
+                for arg in args {
+                    check_binop_types_in_expr(arg, ctx, file, report);
+                }
+            }
+            Statement::Return(value) | Statement::Expr(value) => {
+                check_binop_types_in_expr(value, ctx, file, report);
+            }
+            Statement::Send { message, .. } => {
+                check_binop_types_in_expr(message, ctx, file, report);
+            }
+            Statement::Spawn { args, .. } => {
+                for arg in args {
+                    check_binop_types_in_expr(arg, ctx, file, report);
+                }
+            }
+            Statement::If {
+                condition,
+                then_block,
+                else_block,
+                ..
+            } => {
+                check_binop_types_in_expr(condition, ctx, file, report);
+                let saved = ctx.variables.clone();
+                validate_expression_types(then_block, ctx, file, report);
+                ctx.variables = saved.clone();
+                if let Some(else_block) = else_block {
+                    validate_expression_types(else_block, ctx, file, report);
+                }
+                ctx.variables = saved;
+            }
+            Statement::Match { scrutinee, arms } => {
+                check_binop_types_in_expr(scrutinee, ctx, file, report);
+                let saved = ctx.variables.clone();
+                for arm in arms {
+                    ctx.variables = saved.clone();
+                    validate_expression_types(&arm.body, ctx, file, report);
+                }
+                ctx.variables = saved;
+            }
+        }
+    }
+}
+
+/// Recursively check binary operator operand type compatibility in an expression.
+fn check_binop_types_in_expr(
+    expr: &Expr,
+    ctx: &TypeContext<'_>,
+    file: &str,
+    report: &mut ValidationReport,
+) {
+    match expr {
+        Expr::BinOp(left, op, right) => {
+            check_binop_types_in_expr(left, ctx, file, report);
+            check_binop_types_in_expr(right, ctx, file, report);
+
+            // Only report when we can infer both sides AND neither is generic.
+            if let (Some(left_ty), Some(right_ty)) =
+                (infer_expr_type(left, ctx), infer_expr_type(right, ctx))
+            {
+                if !types_compatible(&left_ty, &right_ty, ctx.generic_params) {
+                    use crate::ast::BinOp::*;
+                    let op_str = match op {
+                        Add => "+",
+                        Sub => "-",
+                        Mul => "*",
+                        Div => "/",
+                        Mod => "%",
+                        Eq => "==",
+                        Neq => "!=",
+                        Lt => "<",
+                        Lte => "<=",
+                        Gt => ">",
+                        Gte => ">=",
+                        And => "&&",
+                        Or => "||",
+                    };
+                    report.errors.push(GustError {
+                        file: file.to_string(),
+                        line: 0,
+                        col: 0,
+                        message: format!(
+                            "binary operator '{}' has incompatible operand types: {} vs {}",
+                            op_str,
+                            format_type_expr(&left_ty),
+                            format_type_expr(&right_ty),
+                        ),
+                        note: Some(
+                            "both operands of a binary operator must have the same type"
+                                .to_string(),
+                        ),
+                        help: None,
+                    });
+                }
+            }
+        }
+        Expr::UnaryOp(_, inner) => check_binop_types_in_expr(inner, ctx, file, report),
+        Expr::FieldAccess(base, _) => check_binop_types_in_expr(base, ctx, file, report),
+        Expr::FnCall(_, args) | Expr::Perform(_, args) => {
+            for a in args {
+                check_binop_types_in_expr(a, ctx, file, report);
+            }
+        }
+        // Leaves: nothing to recurse into.
+        Expr::IntLit(_)
+        | Expr::FloatLit(_)
+        | Expr::StringLit(_)
+        | Expr::BoolLit(_)
+        | Expr::Ident(_)
+        | Expr::Path(_, _) => {}
+    }
+}
+
+// === If/else branch termination consistency (issue #30 item 3) ===
+
+/// Warn when an `if/else` has one branch that terminates (goto/return/exhaustive match)
+/// and another branch that falls through. This catches "forgot to goto in one branch"
+/// bugs that would otherwise only surface as the generic whole-handler fall-through warning.
+fn check_if_branch_consistency(
+    block: &Block,
+    handler_name: &str,
+    enum_variants: &HashMap<String, Vec<String>>,
+    file: &str,
+    report: &mut ValidationReport,
+) {
+    for stmt in &block.statements {
+        match stmt {
+            Statement::If {
+                then_block,
+                else_block,
+                ..
+            } => {
+                // Recurse first so nested if/else are checked independently.
+                check_if_branch_consistency(then_block, handler_name, enum_variants, file, report);
+                if let Some(else_block) = else_block {
+                    check_if_branch_consistency(
+                        else_block,
+                        handler_name,
+                        enum_variants,
+                        file,
+                        report,
+                    );
+
+                    let then_terminates = block_always_terminates(then_block, enum_variants);
+                    let else_terminates = block_always_terminates(else_block, enum_variants);
+                    if then_terminates != else_terminates {
+                        let (fall_through_branch, terminating_branch) = if then_terminates {
+                            ("else", "then")
+                        } else {
+                            ("then", "else")
+                        };
+                        report.warnings.push(GustWarning {
+                            file: file.to_string(),
+                            line: 0,
+                            col: 0,
+                            message: format!(
+                                "handler '{}' has inconsistent if/else: the {} branch transitions but the {} branch may fall through",
+                                handler_name, terminating_branch, fall_through_branch,
+                            ),
+                            note: Some(
+                                "either add a goto/return to the fall-through branch, or remove the goto from the other branch"
+                                    .to_string(),
+                            ),
+                        });
+                    }
+                }
+            }
+            Statement::Match { arms, .. } => {
+                for arm in arms {
+                    check_if_branch_consistency(
+                        &arm.body,
+                        handler_name,
+                        enum_variants,
+                        file,
+                        report,
+                    );
+                }
             }
             _ => {}
         }

--- a/gust-lang/tests/diagnostics_validation.rs
+++ b/gust-lang/tests/diagnostics_validation.rs
@@ -1350,3 +1350,319 @@ machine Demo {
         report.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
     );
 }
+
+// === Effect return type checking (issue #30 item 2) ===
+
+#[test]
+fn validator_allows_matching_let_perform_annotation() {
+    let source = r#"
+machine Fetcher {
+    state Start
+    state Done(msg: String)
+
+    transition run: Start -> Done
+
+    effect load(key: String) -> String
+
+    on run() {
+        let s: String = perform load("x");
+        goto Done(s);
+    }
+}
+"#;
+    let program = parse_program_with_errors(source, "test.gu").expect("should parse");
+    let report = validate_program(&program, "test.gu", source);
+
+    assert!(
+        !report
+            .errors
+            .iter()
+            .any(|e| e.message.contains("annotated as") && e.message.contains("returns")),
+        "should not report mismatch when annotation matches effect return, got errors: {:?}",
+        report.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn validator_rejects_mismatched_let_perform_annotation() {
+    let source = r#"
+machine Fetcher {
+    state Start
+    state Done(n: i64)
+
+    transition run: Start -> Done
+
+    effect load(key: String) -> String
+
+    on run() {
+        let n: i64 = perform load("x");
+        goto Done(n);
+    }
+}
+"#;
+    let program = parse_program_with_errors(source, "test.gu").expect("should parse");
+    let report = validate_program(&program, "test.gu", source);
+
+    assert!(
+        report.errors.iter().any(|e| e
+            .message
+            .contains("annotated as i64, but effect 'load' returns String")),
+        "should report annotation/return mismatch, got errors: {:?}",
+        report.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn validator_skips_perform_annotation_check_for_unknown_effect() {
+    let source = r#"
+machine Worker {
+    state Idle
+    state Done
+
+    transition go: Idle -> Done
+
+    on go() {
+        let n: i64 = perform unknown_effect();
+        goto Done();
+    }
+}
+"#;
+    let program = parse_program_with_errors(source, "test.gu").expect("should parse");
+    let report = validate_program(&program, "test.gu", source);
+
+    // Unknown effect is reported separately; no annotation mismatch should fire.
+    assert!(
+        !report
+            .errors
+            .iter()
+            .any(|e| e.message.contains("annotated as") && e.message.contains("returns")),
+        "should not report annotation mismatch for unknown effect, got errors: {:?}",
+        report.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+}
+
+// === If/else branch termination consistency (issue #30 item 3) ===
+
+#[test]
+fn validator_warns_when_one_branch_terminates_and_other_falls_through() {
+    let source = r#"
+machine Router {
+    state Start(cond: bool)
+    state Done
+
+    transition check: Start -> Done
+
+    on check(ctx: Ctx) {
+        if ctx.cond {
+            goto Done();
+        } else {
+            let x: i64 = 1;
+        }
+    }
+}
+"#;
+    let program = parse_program_with_errors(source, "test.gu").expect("should parse");
+    let report = validate_program(&program, "test.gu", source);
+
+    assert!(
+        report
+            .warnings
+            .iter()
+            .any(|w| w.message.contains("inconsistent if/else")
+                && w.message.contains("may fall through")),
+        "should warn on inconsistent if/else termination, got warnings: {:?}",
+        report
+            .warnings
+            .iter()
+            .map(|w| &w.message)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn validator_no_warning_when_both_branches_terminate() {
+    let source = r#"
+machine Router {
+    state Start(cond: bool)
+    state DoneA
+    state DoneB
+
+    transition check: Start -> DoneA | DoneB
+
+    on check(ctx: Ctx) {
+        if ctx.cond {
+            goto DoneA();
+        } else {
+            goto DoneB();
+        }
+    }
+}
+"#;
+    let program = parse_program_with_errors(source, "test.gu").expect("should parse");
+    let report = validate_program(&program, "test.gu", source);
+
+    assert!(
+        !report
+            .warnings
+            .iter()
+            .any(|w| w.message.contains("inconsistent if/else")),
+        "should not warn when both branches terminate, got warnings: {:?}",
+        report
+            .warnings
+            .iter()
+            .map(|w| &w.message)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn validator_no_warning_when_neither_branch_terminates() {
+    let source = r#"
+machine Router {
+    state Start(cond: bool)
+    state Done
+
+    transition check: Start -> Done
+
+    on check(ctx: Ctx) {
+        if ctx.cond {
+            let a: i64 = 1;
+        } else {
+            let b: i64 = 2;
+        }
+        goto Done();
+    }
+}
+"#;
+    let program = parse_program_with_errors(source, "test.gu").expect("should parse");
+    let report = validate_program(&program, "test.gu", source);
+
+    assert!(
+        !report
+            .warnings
+            .iter()
+            .any(|w| w.message.contains("inconsistent if/else")),
+        "should not warn when neither branch terminates, got warnings: {:?}",
+        report
+            .warnings
+            .iter()
+            .map(|w| &w.message)
+            .collect::<Vec<_>>()
+    );
+}
+
+// === Binary expression operand compatibility (issue #30 item 4) ===
+
+#[test]
+fn validator_allows_matching_binop_operands() {
+    let source = r#"
+machine Calc {
+    state Start(a: i64)
+    state Done(result: i64)
+
+    transition go: Start -> Done
+
+    on go(ctx: Ctx) {
+        let r: i64 = ctx.a + 1;
+        goto Done(r);
+    }
+}
+"#;
+    let program = parse_program_with_errors(source, "test.gu").expect("should parse");
+    let report = validate_program(&program, "test.gu", source);
+
+    assert!(
+        !report
+            .errors
+            .iter()
+            .any(|e| e.message.contains("binary operator")),
+        "should not report mismatch for matching operands, got errors: {:?}",
+        report.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn validator_rejects_mismatched_binop_operands_int_vs_string() {
+    let source = r#"
+machine Calc {
+    state Start
+    state Done(result: i64)
+
+    transition go: Start -> Done
+
+    on go() {
+        let r: i64 = 1 + "two";
+        goto Done(r);
+    }
+}
+"#;
+    let program = parse_program_with_errors(source, "test.gu").expect("should parse");
+    let report = validate_program(&program, "test.gu", source);
+
+    assert!(
+        report.errors.iter().any(|e| e
+            .message
+            .contains("binary operator '+' has incompatible operand types: i64 vs String")),
+        "should report int + string mismatch, got errors: {:?}",
+        report.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn validator_rejects_mismatched_comparison_operands() {
+    let source = r#"
+machine Router {
+    state Start(cond: bool)
+    state Done
+
+    transition go: Start -> Done
+
+    on go(ctx: Ctx) {
+        if 1 == "one" {
+            goto Done();
+        } else {
+            goto Done();
+        }
+    }
+}
+"#;
+    let program = parse_program_with_errors(source, "test.gu").expect("should parse");
+    let report = validate_program(&program, "test.gu", source);
+
+    assert!(
+        report.errors.iter().any(|e| e
+            .message
+            .contains("binary operator '==' has incompatible operand types")),
+        "should report == operand mismatch, got errors: {:?}",
+        report.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn validator_skips_binop_check_when_operand_type_unknown() {
+    let source = r#"
+machine Calc {
+    state Start
+    state Done(result: i64)
+
+    transition go: Start -> Done
+
+    on go() {
+        let r: i64 = unknown_fn() + 1;
+        goto Done(r);
+    }
+}
+"#;
+    let program = parse_program_with_errors(source, "test.gu").expect("should parse");
+    let report = validate_program(&program, "test.gu", source);
+
+    // Can't infer unknown_fn()'s return; check should skip rather than false-positive.
+    assert!(
+        !report
+            .errors
+            .iter()
+            .any(|e| e.message.contains("binary operator") && e.message.contains("incompatible")),
+        "should skip binop check when operand type is unknown, got errors: {:?}",
+        report.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
## Summary

Closes #30 by shipping the remaining three sub-items on top of the goto field type validation that landed in #44.

## Items

### Item 2 — effect return type checking
`let x: T = perform e(...)` is now rejected when the annotated `T` does not match the effect's declared return type. Unknown effects are silently skipped (they're already reported separately by the undeclared-effect check).

### Item 3 — if/else branch termination consistency
Warns when one branch of an `if/else` terminates (goto/return/exhaustive match) but the other falls through. Catches the "forgot to goto in one branch" bug that the existing whole-handler fall-through warning glosses over.

Reuses the `block_always_terminates` + `enum_variants` machinery from #43 so an exhaustive enum match counts as termination.

### Item 4 — binary operator operand compatibility
Walks every expression and reports binary operators whose two operands resolve to incompatible concrete types (e.g. `1 + "two"`, `1 == "one"`). Conservative — if either operand's type can't be inferred, the check is skipped rather than emitting a false positive.

## Design notes

- All three checks live in `validate_expression_types` (items 2 + 4) and `check_if_branch_consistency` (item 3), both wired into the existing per-handler loop.
- Both use the `TypeContext` scaffolding introduced by #44, so no new inference infrastructure was needed.
- Scope reset at if/else and match-arm boundaries matches the existing goto-type-validation behavior — branches don't leak bindings to siblings or parents.

## Known limitation

`Statement::If` and `Expr::BinOp` do not carry spans in the current AST, so diagnostics from items 3 and 4 report at line 0, col 0. Adding spans to these nodes is a separate follow-up (apply the #13 pattern to expression and nested-statement nodes).

## Test Plan

- [x] `cargo test -p gust-lang --test diagnostics_validation` — 56 tests pass (46 existing, 10 new)
- [x] `cargo test --workspace --all-targets --all-features` — no regressions
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`

## Test coverage added

Item 2:
- match: annotated type compatible with effect return → no error
- mismatch: annotation vs effect return → error
- unknown effect: annotation check is skipped

Item 3:
- one branch terminates, other falls through → warning
- both branches terminate → no warning
- neither branch terminates → no warning (other checks cover this)

Item 4:
- matching operand types → no error
- `i64 + String` → error
- `1 == "one"` (comparison) → error
- unknown operand type → no error (conservative)

Closes #30.

---
Generated with [Claude Code](https://claude.ai/code)