### PR TITLE
feat(stdlib): add EngineFailure enum (#40 PR 1 of 4)

### DIFF
--- a/gust-stdlib/build.rs
+++ b/gust-stdlib/build.rs
@@ -6,6 +6,7 @@ fn main() {
         "retry.gu",
         "rate_limiter.gu",
         "health_check.gu",
+        "engine_failure.gu",
     ] {
         println!("cargo:rerun-if-changed={}", file);
     }

--- a/gust-stdlib/engine_failure.gu
+++ b/gust-stdlib/engine_failure.gu
@@ -1,0 +1,53 @@
+// EngineFailure: typed runtime/engine failure for workflow-style machines.
+//
+// Corsac and other workflow runtimes use Gust as the contract language for
+// compiled workflows. They need a stable, typed failure surface so that
+// retry policies, replay semantics, and observability can reason about
+// failures without parsing strings.
+//
+// This file ships as `gust_stdlib::ENGINE_FAILURE`. Import it in a .gu
+// project with:
+//
+//     use std::EngineFailure;
+//
+// and use the variants in state field types, e.g.:
+//
+//     state Failed(failure: EngineFailure)
+//
+// Domain-specific failure enums can wrap this to preserve the engine
+// layer while adding domain variants:
+//
+//     enum SlackFailure {
+//         Engine(EngineFailure),
+//         RateLimited(i64),
+//         ChannelNotFound(String),
+//     }
+//
+// Variant payload positions (documented here because Gust enum variants
+// currently take positional types, not named fields):
+//
+//   UserError(reason)
+//       reason: String
+//
+//   SystemError(reason, attempt)
+//       reason:  String  -- human-readable description
+//       attempt: i64     -- attempt number (1-based)
+//
+//   IntegrationError(service, status_code, body)
+//       service:     String  -- downstream service identifier
+//       status_code: i64     -- HTTP-style status from the service
+//       body:        String  -- raw response body
+//
+//   Timeout(wall_clock_ms)
+//       wall_clock_ms: i64   -- elapsed milliseconds at the timeout
+//
+//   Cancelled(requested_by)
+//       requested_by: String -- opaque canceller identifier
+
+enum EngineFailure {
+    UserError(String),
+    SystemError(String, i64),
+    IntegrationError(String, i64, String),
+    Timeout(i64),
+    Cancelled(String),
+}

--- a/gust-stdlib/src/lib.rs
+++ b/gust-stdlib/src/lib.rs
@@ -18,14 +18,20 @@
 //! | **HealthCheck** | [`HEALTH_CHECK`] | Models service health with `Healthy`, `Degraded`, and `Unhealthy` states, tracking consecutive failures before transitioning. |
 //! | **RequestResponse** | [`REQUEST_RESPONSE`] | Models an async request lifecycle with `Pending`, `Completed`, `Failed`, and `TimedOut` states. |
 //!
+//! ## Available types
+//!
+//! | Type | Constant | Description |
+//! |------|----------|-------------|
+//! | **EngineFailure** | [`ENGINE_FAILURE`] | Typed runtime/engine failure for workflow-style machines: `UserError`, `SystemError`, `IntegrationError`, `Timeout`, `Cancelled`. |
+//!
 //! ## Usage
 //!
-//! Use [`all_sources`] to iterate over every machine source for bulk
-//! compilation, or access individual constants directly:
+//! Use [`all_sources`] to iterate over every standard-library source for
+//! bulk compilation, or access individual constants directly:
 //!
 //! ```rust
 //! let sources = gust_stdlib::all_sources();
-//! assert_eq!(sources.len(), 6);
+//! assert_eq!(sources.len(), 7);
 //!
 //! // Each entry is a (filename, source_code) pair
 //! for (filename, source) in &sources {
@@ -91,6 +97,25 @@ pub const RATE_LIMITER: &str = include_str!("../rate_limiter.gu");
 /// Generic over `T` for the health status payload type.
 pub const HEALTH_CHECK: &str = include_str!("../health_check.gu");
 
+/// The Gust source for the **EngineFailure** enum.
+///
+/// A typed runtime/engine failure surface for workflow-style machines.
+/// Workflow runtimes (e.g. Corsac) use this as a stable failure type so
+/// retry policies, replay semantics, and observability can reason about
+/// failures without parsing strings. Domain-specific failure enums can
+/// wrap `EngineFailure` to preserve the engine layer while adding
+/// domain variants.
+///
+/// Variants (positional payloads — see the source for field descriptions):
+/// - `UserError(String)`
+/// - `SystemError(String, i64)`
+/// - `IntegrationError(String, i64, String)`
+/// - `Timeout(i64)`
+/// - `Cancelled(String)`
+///
+/// Import in a `.gu` file with `use std::EngineFailure;`.
+pub const ENGINE_FAILURE: &str = include_str!("../engine_failure.gu");
+
 /// Returns all standard library machine sources as an array of
 /// `(filename, source_code)` pairs.
 ///
@@ -101,7 +126,7 @@ pub const HEALTH_CHECK: &str = include_str!("../health_check.gu");
 ///
 /// ```rust
 /// let sources = gust_stdlib::all_sources();
-/// assert_eq!(sources.len(), 6);
+/// assert_eq!(sources.len(), 7);
 ///
 /// // Find a specific machine by filename
 /// let circuit_breaker = sources.iter()
@@ -109,7 +134,7 @@ pub const HEALTH_CHECK: &str = include_str!("../health_check.gu");
 ///     .expect("circuit_breaker.gu should exist");
 /// assert!(circuit_breaker.1.contains("machine CircuitBreaker"));
 /// ```
-pub fn all_sources() -> [(&'static str, &'static str); 6] {
+pub fn all_sources() -> [(&'static str, &'static str); 7] {
     [
         ("request_response.gu", REQUEST_RESPONSE),
         ("circuit_breaker.gu", CIRCUIT_BREAKER),
@@ -117,5 +142,6 @@ pub fn all_sources() -> [(&'static str, &'static str); 6] {
         ("retry.gu", RETRY),
         ("rate_limiter.gu", RATE_LIMITER),
         ("health_check.gu", HEALTH_CHECK),
+        ("engine_failure.gu", ENGINE_FAILURE),
     ]
 }

--- a/gust-stdlib/tests/machine_tests.rs
+++ b/gust-stdlib/tests/machine_tests.rs
@@ -1080,10 +1080,19 @@ mod health_check {
 mod cross_cutting {
     use super::*;
 
+    /// All sources that are expected to contain exactly one machine.
+    /// Excludes type-only sources like `engine_failure.gu`.
+    fn machine_sources() -> Vec<(&'static str, &'static str)> {
+        gust_stdlib::all_sources()
+            .into_iter()
+            .filter(|(name, _)| *name != "engine_failure.gu")
+            .collect()
+    }
+
     #[test]
-    fn all_sources_returns_six_entries() {
+    fn all_sources_returns_seven_entries() {
         let sources = gust_stdlib::all_sources();
-        assert_eq!(sources.len(), 6);
+        assert_eq!(sources.len(), 7);
     }
 
     #[test]
@@ -1099,6 +1108,7 @@ mod cross_cutting {
                 "retry.gu",
                 "rate_limiter.gu",
                 "health_check.gu",
+                "engine_failure.gu",
             ]
         );
     }
@@ -1118,8 +1128,12 @@ mod cross_cutting {
     }
 
     #[test]
-    fn all_sources_have_exactly_one_machine() {
-        for (file, source) in &gust_stdlib::all_sources() {
+    fn machine_sources_have_exactly_one_machine() {
+        // engine_failure.gu is a type-only source; skip it here.
+        for (file, source) in gust_stdlib::all_sources()
+            .iter()
+            .filter(|(name, _)| *name != "engine_failure.gu")
+        {
             let program = parse(source, file);
             assert_eq!(
                 program.machines.len(),
@@ -1130,8 +1144,9 @@ mod cross_cutting {
     }
 
     #[test]
-    fn all_sources_have_no_type_declarations() {
-        for (file, source) in &gust_stdlib::all_sources() {
+    fn machine_sources_have_no_type_declarations() {
+        // Type-only sources (engine_failure.gu) are handled separately.
+        for (file, source) in machine_sources() {
             let program = parse(source, file);
             assert!(
                 program.types.is_empty(),
@@ -1164,7 +1179,7 @@ mod cross_cutting {
 
     #[test]
     fn all_machines_have_generic_params() {
-        for (file, source) in &gust_stdlib::all_sources() {
+        for (file, source) in machine_sources() {
             let m = first_machine(source, file);
             assert!(
                 !m.generic_params.is_empty(),
@@ -1175,7 +1190,7 @@ mod cross_cutting {
 
     #[test]
     fn all_machines_have_at_least_two_states() {
-        for (file, source) in &gust_stdlib::all_sources() {
+        for (file, source) in machine_sources() {
             let m = first_machine(source, file);
             assert!(
                 m.states.len() >= 2,
@@ -1187,7 +1202,7 @@ mod cross_cutting {
 
     #[test]
     fn all_machines_have_at_least_one_effect() {
-        for (file, source) in &gust_stdlib::all_sources() {
+        for (file, source) in machine_sources() {
             let m = first_machine(source, file);
             assert!(
                 !m.effects.is_empty(),
@@ -1198,7 +1213,7 @@ mod cross_cutting {
 
     #[test]
     fn all_machines_have_matching_handler_count() {
-        for (file, source) in &gust_stdlib::all_sources() {
+        for (file, source) in machine_sources() {
             let m = first_machine(source, file);
             assert_eq!(
                 m.transitions.len(),
@@ -1210,7 +1225,7 @@ mod cross_cutting {
 
     #[test]
     fn handler_names_match_transition_names() {
-        for (file, source) in &gust_stdlib::all_sources() {
+        for (file, source) in machine_sources() {
             let m = first_machine(source, file);
             let transition_names: Vec<&str> =
                 m.transitions.iter().map(|t| t.name.as_str()).collect();
@@ -1226,7 +1241,7 @@ mod cross_cutting {
 
     #[test]
     fn every_handler_body_has_at_least_one_goto() {
-        for (file, source) in &gust_stdlib::all_sources() {
+        for (file, source) in machine_sources() {
             let m = first_machine(source, file);
             for handler in &m.handlers {
                 let has_goto = has_goto_in_block(&handler.body);
@@ -1283,8 +1298,9 @@ mod cross_cutting {
     }
 
     #[test]
-    fn go_codegen_all_contain_json_tags() {
-        for (file, source) in &gust_stdlib::all_sources() {
+    fn machine_go_codegen_contain_json_tags() {
+        // json tags are on state struct fields; type-only sources have none.
+        for (file, source) in machine_sources() {
             let code = go_codegen(source, file);
             assert!(
                 code.contains("json:"),
@@ -1295,7 +1311,7 @@ mod cross_cutting {
 
     #[test]
     fn rust_and_go_codegen_preserve_state_names() {
-        for (file, source) in &gust_stdlib::all_sources() {
+        for (file, source) in machine_sources() {
             let m = first_machine(source, file);
             let rust_code = rust_codegen(source, file);
             let go_code = go_codegen(source, file);
@@ -1313,6 +1329,126 @@ mod cross_cutting {
                 );
             }
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// EngineFailure (type-only source) tests
+// ---------------------------------------------------------------------------
+
+mod engine_failure {
+    use super::*;
+
+    const FILE: &str = "engine_failure.gu";
+    const SRC: &str = gust_stdlib::ENGINE_FAILURE;
+
+    #[test]
+    fn parses_successfully() {
+        let _ = parse(SRC, FILE);
+    }
+
+    #[test]
+    fn validation_passes() {
+        let program = parse_program_with_errors(SRC, FILE).expect("should parse");
+        let report = validate_program(&program, FILE, SRC);
+        assert!(report.is_ok(), "validation failed: {:?}", report.errors);
+    }
+
+    #[test]
+    fn declares_exactly_one_enum() {
+        let program = parse(SRC, FILE);
+        assert_eq!(program.types.len(), 1, "should declare exactly one type");
+        assert!(program.machines.is_empty(), "should declare no machines");
+        match &program.types[0] {
+            gust_lang::ast::TypeDecl::Enum { name, .. } => {
+                assert_eq!(name, "EngineFailure");
+            }
+            other => panic!("expected Enum, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn has_all_five_variants() {
+        let program = parse(SRC, FILE);
+        let gust_lang::ast::TypeDecl::Enum { variants, .. } = &program.types[0] else {
+            panic!("expected enum");
+        };
+        let names: Vec<&str> = variants.iter().map(|v| v.name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec![
+                "UserError",
+                "SystemError",
+                "IntegrationError",
+                "Timeout",
+                "Cancelled",
+            ]
+        );
+    }
+
+    #[test]
+    fn variant_payload_arity_matches_spec() {
+        let program = parse(SRC, FILE);
+        let gust_lang::ast::TypeDecl::Enum { variants, .. } = &program.types[0] else {
+            panic!("expected enum");
+        };
+        let by_name: std::collections::HashMap<&str, usize> = variants
+            .iter()
+            .map(|v| (v.name.as_str(), v.payload.len()))
+            .collect();
+        assert_eq!(by_name["UserError"], 1, "UserError(reason)");
+        assert_eq!(by_name["SystemError"], 2, "SystemError(reason, attempt)");
+        assert_eq!(
+            by_name["IntegrationError"], 3,
+            "IntegrationError(service, status_code, body)"
+        );
+        assert_eq!(by_name["Timeout"], 1, "Timeout(wall_clock_ms)");
+        assert_eq!(by_name["Cancelled"], 1, "Cancelled(requested_by)");
+    }
+
+    #[test]
+    fn rust_codegen_emits_serde_derived_enum() {
+        let code = rust_codegen(SRC, FILE);
+        assert!(code.contains("pub enum EngineFailure"));
+        assert!(code.contains("UserError(String)"));
+        assert!(code.contains("SystemError(String, i64)"));
+        assert!(code.contains("IntegrationError(String, i64, String)"));
+        assert!(code.contains("Timeout(i64)"));
+        assert!(code.contains("Cancelled(String)"));
+        assert!(code.contains("Serialize") && code.contains("Deserialize"));
+    }
+
+    #[test]
+    fn go_codegen_emits_type_and_constants() {
+        let code = go_codegen(SRC, FILE);
+        assert!(code.contains("type EngineFailure"));
+        for variant in [
+            "EngineFailureUserError",
+            "EngineFailureSystemError",
+            "EngineFailureIntegrationError",
+            "EngineFailureTimeout",
+            "EngineFailureCancelled",
+        ] {
+            assert!(code.contains(variant), "Go codegen missing {variant}");
+        }
+    }
+
+    #[test]
+    fn usable_as_state_field_type_in_downstream_machine() {
+        // Smoke test: a downstream machine can declare a state whose field
+        // is typed `EngineFailure` alongside the enum declaration.
+        // (Constructing variants with payloads is a separate grammar feature.)
+        let combined = format!(
+            "{}\n\nmachine Demo {{\n    state Running\n    state Failed(failure: EngineFailure)\n\n    transition fail: Running -> Failed\n\n    effect produce_failure() -> EngineFailure\n\n    on fail() {{\n        let f: EngineFailure = perform produce_failure();\n        goto Failed(f);\n    }}\n}}\n",
+            SRC
+        );
+        let program = parse_program_with_errors(&combined, "demo.gu").expect("should parse");
+        let report = validate_program(&program, "demo.gu", &combined);
+        assert!(
+            report.is_ok(),
+            "downstream use should validate: {:?}",
+            report.errors
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

First deliverable for #40. Adds a `.gu` source file defining `EngineFailure`, a typed runtime/engine failure enum for workflow-style machines. Corsac and other workflow runtimes can use this as a stable failure type for retry policies, replay semantics, and observability.

## Why

Corsac uses Gust as the contract language for compiled workflows. Phase 1 of their runtime uses node-boundary checkpoints instead of full event-sourced replay, so they need a typed failure surface that isn't backend-specific. Without `EngineFailure` in the stdlib, each workflow runtime defines its own failure type and retry policies can't be portable across them.

## Scope of this PR

**Pure-additive.** Zero compiler, parser, or codegen changes. Just:

- New file `gust-stdlib/engine_failure.gu` holding the enum exactly as agreed in the plan comment.
- `pub const ENGINE_FAILURE: &str = include_str!("../engine_failure.gu");` in `lib.rs`.
- Added to `all_sources()` (now returns 7 entries).
- Cross-cutting tests that assumed "every source is a machine" now use a `machine_sources()` helper to skip type-only sources.

Downstream users import via `use std::EngineFailure;` in their `.gu` files; the existing `use_decl` passes through to target-language imports.

## Variants

Positional payloads (Gust enum variants currently don't support named fields — position meanings documented inline in the `.gu` file):

| Variant | Payload |
|---|---|
| `UserError(String)` | reason |
| `SystemError(String, i64)` | reason, attempt |
| `IntegrationError(String, i64, String)` | service, status_code, body |
| `Timeout(i64)` | wall_clock_ms |
| `Cancelled(String)` | requested_by |

## Deviation from the issue sketch

The issue showed named fields in the enum variants (e.g. `UserError(reason: String)`). Gust's current grammar only supports positional payload types on enum variants. Named fields would be a grammar extension worth its own discussion — keeping this PR additive. Position meanings are spelled out in the `.gu` file's header comment.

## Test Plan

- [x] `cargo test -p gust-stdlib` — 121 passed (113 existing, 8 new engine_failure tests)
- [x] `cargo test --workspace --all-targets --all-features` — no regressions
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `gust check gust-stdlib/engine_failure.gu` — passes
- [x] `gust build ... --target rust` — emits `pub enum EngineFailure` with serde derives
- [x] `gust build ... --target go --package engine` — emits `type EngineFailure` + constants

### Tests added

- Parses successfully
- Validation passes
- Declares exactly one enum named `EngineFailure`, zero machines
- Has all five variants in order
- Variant payload arity matches spec
- Rust codegen emits serde-derived enum with all five variants
- Go codegen emits type + variant constants
- Usable as a state field type in a downstream machine

## Follow-up PRs on #40

- PR 2: `action` keyword in parser/AST (`EffectKind` on `EffectDecl`)
- PR 3: `effect` vs `action` exposed in codegen + MCP metadata
- PR 4: handler-safety diagnostics for `action` usage

Related: #40.

---
Generated with [Claude Code](https://claude.ai/code)