### PR TITLE
feat(lang): add `action` keyword (#40 PR 2 of 4)

### DIFF
--- a/gust-lang/src/ast.rs
+++ b/gust-lang/src/ast.rs
@@ -121,12 +121,37 @@ pub struct TransitionDecl {
     pub span: Span,
 }
 
+/// Classifies a side-effectful declaration as `effect` (replay-safe /
+/// idempotent) or `action` (not idempotent, externally visible).
+///
+/// Both share the same syntactic shape and codegen lowering in v0.1;
+/// replay-aware runtimes and workflow tooling use the distinction to
+/// decide retry and checkpoint semantics. See issue #40.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EffectKind {
+    Effect,
+    Action,
+}
+
+impl EffectKind {
+    /// The source keyword that introduced this declaration.
+    pub fn keyword(self) -> &'static str {
+        match self {
+            EffectKind::Effect => "effect",
+            EffectKind::Action => "action",
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct EffectDecl {
     pub name: String,
     pub params: Vec<Field>,
     pub return_type: TypeExpr,
     pub is_async: bool,
+    /// Distinguishes `effect` (replay-safe) from `action` (not replay-safe).
+    /// See [`EffectKind`] and issue #40.
+    pub kind: EffectKind,
     pub span: Span,
 }
 

--- a/gust-lang/src/format.rs
+++ b/gust-lang/src/format.rs
@@ -309,6 +309,8 @@ const DECL_PREFIXES: &[&str] = &[
     "state ",
     "effect ",
     "async effect ",
+    "action ",
+    "async action ",
     "transition ",
     "type ",
     "struct ",
@@ -552,7 +554,8 @@ fn format_machine_with_comments(
             .collect::<Vec<_>>()
             .join(", ");
         out.push_str(&format!(
-            "    {async_kw}effect {}({params}) -> {}\n",
+            "    {async_kw}{} {}({params}) -> {}\n",
+            effect.kind.keyword(),
             effect.name,
             format_type_expr(&effect.return_type)
         ));

--- a/gust-lang/src/grammar.pest
+++ b/gust-lang/src/grammar.pest
@@ -46,7 +46,7 @@ receives_annotation = { "receives" ~ ident }
 supervises_annotation = { "supervises" ~ ident ~ ("(" ~ supervision_strategy ~ ")")? }
 supervision_strategy = { "one_for_one" | "one_for_all" | "rest_for_one" }
 machine_body = { machine_item* }
-machine_item = { state_decl | transition_decl | on_handler | effect_decl }
+machine_item = { state_decl | transition_decl | on_handler | effect_decl | action_decl }
 
 // === State Declarations ===
 state_decl     = { "state" ~ ident ~ ("(" ~ field_list ~ ")")? }
@@ -58,9 +58,13 @@ timeout_spec = { "timeout" ~ duration }
 duration = { int_lit ~ duration_unit }
 duration_unit = { "ms" | "s" | "m" | "h" }
 
-// === Effect Declarations (tracked side effects) ===
+// === Effect and Action Declarations ===
+// `effect`: tracked side effect; assumed replay-safe/idempotent.
+// `action`: non-idempotent externally visible operation; treated differently
+//           by replay-aware runtimes. Same shape as effect, different keyword.
 async_modifier = { "async" }
 effect_decl = { async_modifier? ~ "effect" ~ ident ~ "(" ~ field_list ~ ")" ~ "->" ~ type_expr }
+action_decl = { async_modifier? ~ "action" ~ ident ~ "(" ~ field_list ~ ")" ~ "->" ~ type_expr }
 
 // === Event Handlers ===
 on_handler   = { async_modifier? ~ "on" ~ ident ~ "(" ~ param_list ~ ")" ~ ("->" ~ type_expr)? ~ block }

--- a/gust-lang/src/parser.rs
+++ b/gust-lang/src/parser.rs
@@ -385,7 +385,12 @@ fn parse_machine_decl(pair: Pair<Rule>) -> MachineDecl {
             Rule::state_decl => machine.states.push(parse_state_decl(actual_item)),
             Rule::transition_decl => machine.transitions.push(parse_transition_decl(actual_item)),
             Rule::on_handler => machine.handlers.push(parse_on_handler(actual_item)),
-            Rule::effect_decl => machine.effects.push(parse_effect_decl(actual_item)),
+            Rule::effect_decl => machine
+                .effects
+                .push(parse_effect_or_action_decl(actual_item, EffectKind::Effect)),
+            Rule::action_decl => machine
+                .effects
+                .push(parse_effect_or_action_decl(actual_item, EffectKind::Action)),
             _ => {}
         }
     }
@@ -457,7 +462,7 @@ fn parse_timeout_spec(pair: Pair<Rule>) -> DurationSpec {
     DurationSpec { value, unit }
 }
 
-fn parse_effect_decl(pair: Pair<Rule>) -> EffectDecl {
+fn parse_effect_or_action_decl(pair: Pair<Rule>, kind: EffectKind) -> EffectDecl {
     let span = span_from_pair(&pair);
     let mut inner = pair.into_inner();
     let mut is_async = false;
@@ -475,6 +480,7 @@ fn parse_effect_decl(pair: Pair<Rule>) -> EffectDecl {
         params,
         return_type,
         is_async,
+        kind,
         span,
     }
 }

--- a/gust-lang/tests/action_keyword.rs
+++ b/gust-lang/tests/action_keyword.rs
@@ -1,0 +1,207 @@
+//! Tests for the `action` keyword (#40 PR 2).
+//!
+//! `action` is the non-idempotent / externally visible counterpart to
+//! `effect`. Both share the same syntactic shape and codegen lowering in
+//! v0.1 — the distinction is preserved in the AST (`EffectKind`) and the
+//! formatter so replay-aware runtimes can consume it.
+
+use gust_lang::ast::EffectKind;
+use gust_lang::{format_program, parse_program, validate_program};
+
+const SIMPLE_ACTION_SOURCE: &str = r#"
+machine Notifier {
+    state Idle
+    state Pending(text: String)
+    state Sent(timestamp: String)
+
+    transition send: Pending -> Sent
+
+    action post_message(channel: String, text: String) -> String
+
+    on send(ctx: Ctx) {
+        let ts: String = perform post_message(ctx.text, ctx.text);
+        goto Sent(ts);
+    }
+}
+"#;
+
+#[test]
+fn parses_action_keyword() {
+    let program = parse_program(SIMPLE_ACTION_SOURCE).expect("should parse");
+    let machine = &program.machines[0];
+    assert_eq!(machine.effects.len(), 1);
+    assert_eq!(machine.effects[0].name, "post_message");
+    assert_eq!(machine.effects[0].kind, EffectKind::Action);
+}
+
+#[test]
+fn parses_effect_keyword_as_effect_kind() {
+    let source = r#"
+machine Fetcher {
+    state Start
+    state Done(v: String)
+
+    transition run: Start -> Done
+
+    effect fetch(url: String) -> String
+
+    on run() {
+        let v: String = perform fetch("/");
+        goto Done(v);
+    }
+}
+"#;
+    let program = parse_program(source).expect("should parse");
+    let machine = &program.machines[0];
+    assert_eq!(machine.effects.len(), 1);
+    assert_eq!(machine.effects[0].kind, EffectKind::Effect);
+}
+
+#[test]
+fn parses_mixed_effect_and_action() {
+    let source = r#"
+machine Mixed {
+    state Start
+    state Done(v: String)
+
+    transition go: Start -> Done
+
+    effect compute() -> String
+    action publish(v: String) -> String
+
+    on go() {
+        let a: String = perform compute();
+        let b: String = perform publish(a);
+        goto Done(b);
+    }
+}
+"#;
+    let program = parse_program(source).expect("should parse");
+    let machine = &program.machines[0];
+    assert_eq!(machine.effects.len(), 2);
+    let by_name: std::collections::HashMap<&str, EffectKind> = machine
+        .effects
+        .iter()
+        .map(|e| (e.name.as_str(), e.kind))
+        .collect();
+    assert_eq!(by_name["compute"], EffectKind::Effect);
+    assert_eq!(by_name["publish"], EffectKind::Action);
+}
+
+#[test]
+fn parses_async_action() {
+    let source = r#"
+machine AsyncActor {
+    state Start
+    state Done(v: String)
+
+    transition go: Start -> Done
+
+    async action remote_call(url: String) -> String
+
+    async on go() {
+        let v: String = perform remote_call("/");
+        goto Done(v);
+    }
+}
+"#;
+    let program = parse_program(source).expect("should parse");
+    let machine = &program.machines[0];
+    assert_eq!(machine.effects[0].kind, EffectKind::Action);
+    assert!(machine.effects[0].is_async);
+}
+
+#[test]
+fn validation_accepts_action_same_as_effect() {
+    let program = parse_program(SIMPLE_ACTION_SOURCE).expect("should parse");
+    let report = validate_program(&program, "action.gu", SIMPLE_ACTION_SOURCE);
+    assert!(
+        report.is_ok(),
+        "action should validate identically to effect: {:?}",
+        report.errors
+    );
+}
+
+#[test]
+fn formatter_emits_action_keyword() {
+    let program = parse_program(SIMPLE_ACTION_SOURCE).expect("should parse");
+    let formatted = format_program(&program);
+    assert!(
+        formatted.contains("action post_message("),
+        "formatter should emit `action`, got:\n{formatted}"
+    );
+    assert!(
+        !formatted.contains("effect post_message("),
+        "formatter should not downgrade `action` to `effect`, got:\n{formatted}"
+    );
+}
+
+#[test]
+fn formatter_roundtrip_preserves_kind() {
+    let program = parse_program(SIMPLE_ACTION_SOURCE).expect("first parse");
+    let formatted = format_program(&program);
+    let reparsed = parse_program(&formatted).expect("reparse");
+    assert_eq!(reparsed.machines[0].effects[0].kind, EffectKind::Action);
+}
+
+#[test]
+fn effect_kind_keyword_method() {
+    assert_eq!(EffectKind::Effect.keyword(), "effect");
+    assert_eq!(EffectKind::Action.keyword(), "action");
+}
+
+#[test]
+fn existing_effect_programs_still_parse_and_default_to_effect_kind() {
+    let source = r#"
+machine Legacy {
+    state Start
+    state Done(v: String)
+
+    transition go: Start -> Done
+
+    effect legacy_effect() -> String
+
+    on go() {
+        let v: String = perform legacy_effect();
+        goto Done(v);
+    }
+}
+"#;
+    let program = parse_program(source).expect("should parse");
+    assert_eq!(
+        program.machines[0].effects[0].kind,
+        EffectKind::Effect,
+        "pre-existing `effect` declarations must parse as EffectKind::Effect"
+    );
+}
+
+#[test]
+fn async_effect_and_async_action_both_parse() {
+    let source = r#"
+machine Both {
+    state Start
+    state Done(v: String)
+
+    transition go: Start -> Done
+
+    async effect a() -> String
+    async action b(v: String) -> String
+
+    async on go() {
+        let x: String = perform a();
+        let y: String = perform b(x);
+        goto Done(y);
+    }
+}
+"#;
+    let program = parse_program(source).expect("should parse");
+    let effects = &program.machines[0].effects;
+    assert_eq!(effects.len(), 2);
+    for e in effects {
+        assert!(e.is_async, "{} should be async", e.name);
+    }
+    let by_name: std::collections::HashMap<&str, EffectKind> =
+        effects.iter().map(|e| (e.name.as_str(), e.kind)).collect();
+    assert_eq!(by_name["a"], EffectKind::Effect);
+    assert_eq!(by_name["b"], EffectKind::Action);
+}


### PR DESCRIPTION
## Summary

Second deliverable for #40. Adds the `action` keyword to the grammar and AST, marking declarations as non-idempotent / externally visible in contrast to replay-safe `effect`.

Both keywords share the same syntactic shape and codegen lowering in v0.1 — the distinction lives on a single `kind: EffectKind` field on `EffectDecl` so downstream tooling (workflow runtimes like Corsac, MCP consumers, future replay-aware codegen) can read it without reparsing.

## Changes

- **grammar.pest**: new `action_decl` rule parallel to `effect_decl`, added to `machine_item`.
- **ast.rs**: `EffectKind { Effect, Action }` enum with a `keyword()` helper; new `pub kind: EffectKind` field on `EffectDecl`.
- **parser.rs**: `parse_effect_or_action_decl(pair, kind)` dispatches from the matching grammar rule so the keyword is captured lossless.
- **format.rs**: emits the original keyword via `effect.kind.keyword()`; `action ` and `async action ` added to the declaration-prefix list used by comment preservation.

## Design

Chose a single field on `EffectDecl` over parallel `ActionDecl` / `EffectDecl` types so every codegen path stays DRY and the ~dozen codegen match sites don't need duplication. The distinction is preserved in the AST — it just lives in one place.

`action` currently lowers identically to `effect`. Future PRs in this series will teach codegens and MCP to surface the distinction (PR 3) and add handler-safety diagnostics (PR 4).

## Compatibility

Pure-additive:
- Pre-existing programs using `effect` parse as `EffectKind::Effect` with no behavior change.
- All codegen / LSP / MCP sites already destructure `EffectDecl` with `..`, so the new field doesn't break any match site.
- Validator accepts `action` identically to `effect`.

## Test Plan

- [x] 10 new tests in `gust-lang/tests/action_keyword.rs` (all pass):
  - `action` keyword parses
  - `effect` keyword parses as `EffectKind::Effect`
  - mixed `effect` + `action` in one machine
  - `async action`
  - validator accepts `action` identically to `effect`
  - formatter emits `action` (not `effect`)
  - formatter roundtrip preserves kind
  - `EffectKind::keyword()` returns the right string
  - pre-existing `effect` programs default to `EffectKind::Effect`
  - `async effect` + `async action` together
- [x] `cargo test --workspace --all-targets --all-features` — no regressions
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`

## Follow-up PRs on #40

- PR 3: expose `effect` vs `action` in codegen doc comments and MCP metadata
- PR 4: handler-safety diagnostics for `action` usage

Related: #40.

---
Generated with [Claude Code](https://claude.ai/code)