### PR TITLE
feat(codegen,mcp): surface effect/action distinction (#40 PR 3 of 4)

### DIFF
--- a/gust-lang/src/codegen.rs
+++ b/gust-lang/src/codegen.rs
@@ -369,6 +369,11 @@ pub enum {name}Error {{
             } else {
                 format!(" -> {return_type}")
             };
+            // Mark actions in rustdoc so downstream tooling and humans can
+            // tell them apart without re-parsing the .gu source. See #40.
+            if matches!(effect.kind, EffectKind::Action) {
+                self.line("/// action — not replay-safe / externally visible (#40).");
+            }
             self.line(&format!(
                 "{}fn {}({}){};",
                 if effect.is_async { "async " } else { "" },

--- a/gust-lang/src/codegen_go.rs
+++ b/gust-lang/src/codegen_go.rs
@@ -511,6 +511,11 @@ impl GoCodegen {
             );
             let is_unit = matches!(effect.return_type, TypeExpr::Unit);
             let return_type = self.type_expr_to_go(&effect.return_type);
+            // Mark actions in the generated comment so downstream tooling can
+            // tell them apart without re-parsing the .gu source. See #40.
+            if matches!(effect.kind, EffectKind::Action) {
+                self.line("// action -- not replay-safe / externally visible (#40).");
+            }
             if effect.is_async {
                 if is_unit {
                     self.line(&format!("{}({}) error", method_name, params.join(", "),));

--- a/gust-lang/tests/action_codegen_metadata.rs
+++ b/gust-lang/tests/action_codegen_metadata.rs
@@ -1,0 +1,151 @@
+//! Tests that codegen preserves the `effect` vs `action` distinction (#40 PR 3).
+//!
+//! `action` currently lowers identically to `effect`, but the generated code
+//! must carry a marker (comment / attribute) so downstream tooling and humans
+//! can tell them apart without re-parsing the .gu source.
+
+use gust_lang::{parse_program, GoCodegen, RustCodegen};
+
+const MIXED_SRC: &str = r#"
+machine Hybrid {
+    state Start
+    state Done(v: String)
+
+    transition go: Start -> Done
+
+    effect compute() -> String
+    action publish(v: String) -> String
+
+    on go() {
+        let a: String = perform compute();
+        let b: String = perform publish(a);
+        goto Done(b);
+    }
+}
+"#;
+
+const ONLY_EFFECT_SRC: &str = r#"
+machine Pure {
+    state Start
+    state Done(v: String)
+
+    transition go: Start -> Done
+
+    effect compute() -> String
+
+    on go() {
+        let a: String = perform compute();
+        goto Done(a);
+    }
+}
+"#;
+
+#[test]
+fn rust_codegen_marks_action_methods() {
+    let program = parse_program(MIXED_SRC).expect("should parse");
+    let code = RustCodegen::new().generate(&program);
+
+    // The action method carries the marker comment.
+    assert!(
+        code.contains("/// action — not replay-safe / externally visible (#40)."),
+        "Rust codegen should mark action methods with a rustdoc comment. Got:\n{code}"
+    );
+
+    // The marker appears immediately before the `publish` method.
+    let lines: Vec<&str> = code.lines().collect();
+    let publish_idx = lines
+        .iter()
+        .position(|l| l.contains("fn publish"))
+        .expect("should emit `fn publish`");
+    assert!(publish_idx > 0, "publish should not be at line 0");
+    assert!(
+        lines[publish_idx - 1].contains("action — not replay-safe"),
+        "marker should be directly above fn publish, got:\n{}\n{}",
+        lines[publish_idx - 1],
+        lines[publish_idx]
+    );
+}
+
+#[test]
+fn rust_codegen_does_not_mark_plain_effect_methods() {
+    let program = parse_program(ONLY_EFFECT_SRC).expect("should parse");
+    let code = RustCodegen::new().generate(&program);
+    assert!(
+        !code.contains("action — not replay-safe"),
+        "plain effects must not be marked as actions. Got:\n{code}"
+    );
+    assert!(code.contains("fn compute"));
+}
+
+#[test]
+fn go_codegen_marks_action_methods() {
+    let program = parse_program(MIXED_SRC).expect("should parse");
+    let code = GoCodegen::new().generate(&program, "hybrid");
+
+    assert!(
+        code.contains("// action -- not replay-safe / externally visible (#40)."),
+        "Go codegen should mark action methods with a // comment. Got:\n{code}"
+    );
+
+    // Marker must appear in the interface block, directly before the Publish method.
+    let lines: Vec<&str> = code.lines().collect();
+    let publish_idx = lines
+        .iter()
+        .position(|l| l.contains("Publish("))
+        .expect("Publish method should be generated");
+    assert!(publish_idx > 0, "Publish should not be at line 0");
+    assert!(
+        lines[publish_idx - 1].contains("action -- not replay-safe"),
+        "marker should precede Publish, got:\n{}\n{}",
+        lines[publish_idx - 1],
+        lines[publish_idx]
+    );
+}
+
+#[test]
+fn go_codegen_does_not_mark_plain_effect_methods() {
+    let program = parse_program(ONLY_EFFECT_SRC).expect("should parse");
+    let code = GoCodegen::new().generate(&program, "pure");
+    assert!(
+        !code.contains("action -- not replay-safe"),
+        "plain effects must not be marked as actions. Got:\n{code}"
+    );
+}
+
+#[test]
+fn codegen_marker_count_matches_action_count() {
+    let program = parse_program(MIXED_SRC).expect("should parse");
+    let rust_code = RustCodegen::new().generate(&program);
+    let go_code = GoCodegen::new().generate(&program, "hybrid");
+
+    let rust_markers = rust_code.matches("action — not replay-safe").count();
+    let go_markers = go_code.matches("action -- not replay-safe").count();
+
+    // One `action publish` → exactly one marker per target.
+    assert_eq!(rust_markers, 1, "Rust: expected 1 action marker");
+    assert_eq!(go_markers, 1, "Go: expected 1 action marker");
+}
+
+#[test]
+fn action_only_machine_still_generates_valid_trait() {
+    let source = r#"
+machine OnlyActions {
+    state Start
+    state Done(v: String)
+
+    transition go: Start -> Done
+
+    action publish(v: String) -> String
+
+    on go() {
+        let b: String = perform publish("hi");
+        goto Done(b);
+    }
+}
+"#;
+    let program = parse_program(source).expect("should parse");
+    let code = RustCodegen::new().generate(&program);
+    assert!(code.contains("pub trait OnlyActionsEffects"));
+    assert!(code.contains("fn publish"));
+    assert!(code.contains("action — not replay-safe"));
+}

--- a/gust-mcp/src/lib.rs
+++ b/gust-mcp/src/lib.rs
@@ -560,11 +560,19 @@ pub fn serialize_program(program: &gust_lang::ast::Program) -> Value {
     }
 
     fn serialize_effect(e: &EffectDecl) -> Value {
+        // `kind` distinguishes replay-safe `effect` from non-idempotent
+        // `action`. Downstream workflow runtimes (e.g. Corsac) use this
+        // field to decide retry/checkpoint semantics. See #40.
+        let kind = match e.kind {
+            EffectKind::Effect => "effect",
+            EffectKind::Action => "action",
+        };
         json!({
             "name": e.name,
             "params": e.params.iter().map(serialize_field).collect::<Vec<_>>(),
             "return_type": serialize_type_expr(&e.return_type),
-            "is_async": e.is_async
+            "is_async": e.is_async,
+            "kind": kind
         })
     }
 

--- a/gust-mcp/tests/mcp_tools_test.rs
+++ b/gust-mcp/tests/mcp_tools_test.rs
@@ -1006,3 +1006,73 @@ fn build_complex_machine_generates_complete_rust() {
     );
     assert!(result.contains("Failed"), "should reference error state");
 }
+
+// ---------------------------------------------------------------------------
+// #40: effect vs action distinction in parse output
+// ---------------------------------------------------------------------------
+
+#[test]
+fn parse_effect_and_action_surface_kind_field() {
+    const SRC: &str = r#"
+machine Hybrid {
+    state Start
+    state Done(v: String)
+
+    transition go: Start -> Done
+
+    effect compute() -> String
+    action publish(v: String) -> String
+
+    on go() {
+        let a: String = perform compute();
+        let b: String = perform publish(a);
+        goto Done(b);
+    }
+}
+"#;
+    let f = write_temp_gu(SRC);
+    let args = json!({ "file": f.path().to_str().unwrap() });
+    let result = tool_parse(&args).expect("tool_parse should succeed");
+    let ast: Value = serde_json::from_str(&result).unwrap();
+    let effects = ast["machines"][0]["effects"].as_array().unwrap();
+    assert_eq!(effects.len(), 2);
+
+    let by_name: std::collections::HashMap<String, &Value> = effects
+        .iter()
+        .map(|e| (e["name"].as_str().unwrap().to_string(), e))
+        .collect();
+
+    assert_eq!(
+        by_name["compute"]["kind"], "effect",
+        "effect declarations should be tagged kind=effect"
+    );
+    assert_eq!(
+        by_name["publish"]["kind"], "action",
+        "action declarations should be tagged kind=action"
+    );
+}
+
+#[test]
+fn parse_plain_effect_defaults_to_effect_kind() {
+    const SRC: &str = r#"
+machine Legacy {
+    state Start
+    state Done(v: String)
+
+    transition go: Start -> Done
+
+    effect legacy() -> String
+
+    on go() {
+        let v: String = perform legacy();
+        goto Done(v);
+    }
+}
+"#;
+    let f = write_temp_gu(SRC);
+    let args = json!({ "file": f.path().to_str().unwrap() });
+    let result = tool_parse(&args).expect("tool_parse should succeed");
+    let ast: Value = serde_json::from_str(&result).unwrap();
+    let effects = ast["machines"][0]["effects"].as_array().unwrap();
+    assert_eq!(effects[0]["kind"], "effect");
+}


### PR DESCRIPTION
## Summary

Third deliverable for #40. Exposes the `EffectKind` (effect vs action) distinction in generated code and the MCP `gust_parse` output so workflow runtimes (Corsac) and AI tooling can reason about replay safety without re-parsing .gu source.

## Changes

- **Rust codegen**: emits `/// action — not replay-safe / externally visible (#40).` directly above each action method in the generated `{Machine}Effects` trait.
- **Go codegen**: emits `// action -- not replay-safe / externally visible (#40).` directly above each action method in the generated `{Machine}Effects` interface.
- **MCP `gust_parse`**: effects in the JSON output now include a `"kind": "effect" | "action"` field alongside the existing `name`, `params`, `return_type`, `is_async`.

## Design

**Rendered in each target's natural doc-comment style.** Rustdoc for Rust, `//` for Go. Rendered directly above the method so it sticks to the declaration when code is quoted or grepped. Includes the `#40` backreference so someone finding the marker in a generated file can trace it.

**Open question from the implementation plan** (surface format for Rust): answered here by going with a `///` rustdoc comment rather than a custom attribute like `#[gust::action]`. Rationale: `///` is universal (works with `cargo doc`, rust-analyzer hovers, macro users, plain `grep`) and requires no downstream macro setup. Happy to add a structured attribute later if Corsac or other consumers need it for proc-macro consumption.

## Compatibility

Pure-additive:
- Effects continue to generate identical code.
- MCP output: `kind` is a new field; existing fields unchanged. Existing consumers that don't read `kind` are unaffected.

## Test Plan

- [x] 6 new tests in `gust-lang/tests/action_codegen_metadata.rs`
- [x] 2 new tests in `gust-mcp/tests/mcp_tools_test.rs`
- [x] `cargo test --workspace --all-targets --all-features` — no regressions
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`

### Test coverage

Codegen tests verify:
- Rust marker appears directly above action methods (position-sensitive)
- Rust marker does NOT appear for plain effects
- Go marker appears directly above action methods (position-sensitive)
- Go marker does NOT appear for plain effects
- Marker count == action count in mixed machines
- Action-only machines generate valid traits with markers

MCP tests verify:
- Mixed effect + action machines report `kind: "effect"` and `kind: "action"` correctly
- Legacy `effect`-only programs report `kind: "effect"`

## Follow-up

- PR 4: handler-safety diagnostics for `action` usage
  - Warn when a handler performs >1 `action`
  - Warn when an `action` is not the last side-effectful step before `goto`

Related: #40.

---
Generated with [Claude Code](https://claude.ai/code)