### PR TITLE
feat(validator): handler-safety diagnostics for actions (#40 PR 4 of 4)

### DIFF
--- a/gust-lang/src/validator.rs
+++ b/gust-lang/src/validator.rs
@@ -1,6 +1,6 @@
 use crate::ast::{
-    Block, EffectDecl, Expr, Field, Pattern, Program, Span, StateDecl, Statement, TransitionDecl,
-    TypeDecl, TypeExpr,
+    Block, EffectDecl, EffectKind, Expr, Field, Pattern, Program, Span, StateDecl, Statement,
+    TransitionDecl, TypeDecl, TypeExpr,
 };
 use crate::error::{GustError, GustWarning};
 use std::collections::{HashMap, HashSet};
@@ -48,6 +48,15 @@ pub fn validate_program(program: &Program, file: &str, _source: &str) -> Validat
             machine.effects.iter().map(|e| e.name.clone()).collect();
         let declared_effect_names: Vec<String> =
             machine.effects.iter().map(|e| e.name.clone()).collect();
+        // Names of declarations whose kind is `action`. Used by handler-safety
+        // diagnostics to tell apart replay-safe `effect` from non-idempotent
+        // `action` invocations. See #40.
+        let declared_actions: HashSet<String> = machine
+            .effects
+            .iter()
+            .filter(|e| e.kind == EffectKind::Action)
+            .map(|e| e.name.clone())
+            .collect();
         let state_fields: HashMap<&str, &StateDecl> = machine
             .states
             .iter()
@@ -303,6 +312,16 @@ pub fn validate_program(program: &Program, file: &str, _source: &str) -> Validat
                     note: Some("all handler paths should transition to a new state".to_string()),
                 });
             }
+
+            // Handler-safety diagnostics for actions (#40 item 4).
+            check_handler_action_safety(
+                &handler.body,
+                &handler.transition_name,
+                handler.span,
+                &declared_actions,
+                file,
+                &mut report,
+            );
             validate_send_targets(
                 &handler.body,
                 &declared_channels,
@@ -1546,6 +1565,189 @@ fn check_if_branch_consistency(
             }
             _ => {}
         }
+    }
+}
+
+// === Handler-safety diagnostics for actions (#40 item 4) ===
+
+/// Classification of a single statement's side-effect profile, used to
+/// reason about action placement within a handler body.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SideEffectKind {
+    /// No observable side effect at this statement level (control flow
+    /// and pure bindings fall through here).
+    None,
+    /// A `perform` of a declared `effect` — assumed replay-safe.
+    Effect,
+    /// A `perform` of a declared `action` — not replay-safe.
+    Action,
+    /// `send` or `spawn` — externally visible but not an action.
+    OtherExternal,
+}
+
+/// Warn when a handler performs more than one `action`, or when an action
+/// is not the last side-effectful step before the handler transitions.
+/// Branches (if/else, match arms) are analyzed as independent sequences
+/// so an action in one branch and another in a sibling branch don't
+/// falsely trigger the "more than one" rule.
+fn check_handler_action_safety(
+    block: &Block,
+    handler_name: &str,
+    handler_span: Span,
+    actions: &HashSet<String>,
+    file: &str,
+    report: &mut ValidationReport,
+) {
+    if actions.is_empty() {
+        return;
+    }
+    walk_sequence_for_action_safety(block, handler_name, handler_span, actions, file, report);
+}
+
+fn walk_sequence_for_action_safety(
+    block: &Block,
+    handler_name: &str,
+    handler_span: Span,
+    actions: &HashSet<String>,
+    file: &str,
+    report: &mut ValidationReport,
+) {
+    // Classify each top-level statement.
+    let kinds: Vec<SideEffectKind> = block
+        .statements
+        .iter()
+        .map(|s| classify_statement_side_effect(s, actions))
+        .collect();
+
+    // Rule 1: more than one action in this sequence.
+    let action_count = kinds
+        .iter()
+        .filter(|k| matches!(k, SideEffectKind::Action))
+        .count();
+    if action_count > 1 {
+        report.warnings.push(GustWarning {
+            file: file.to_string(),
+            line: handler_span.start_line,
+            col: handler_span.start_col,
+            message: format!(
+                "handler '{handler_name}' performs {action_count} actions in a single sequence"
+            ),
+            note: Some(
+                "actions are not replay-safe; prefer at most one per handler \
+                 path so workflow runtimes can checkpoint cleanly (#40)"
+                    .to_string(),
+            ),
+        });
+    }
+
+    // Rule 2: action is followed by another side-effectful step.
+    if let Some(last_action_idx) = kinds
+        .iter()
+        .rposition(|k| matches!(k, SideEffectKind::Action))
+    {
+        let has_later_side_effect = kinds
+            .iter()
+            .skip(last_action_idx + 1)
+            .any(|k| !matches!(k, SideEffectKind::None));
+        if has_later_side_effect {
+            report.warnings.push(GustWarning {
+                file: file.to_string(),
+                line: handler_span.start_line,
+                col: handler_span.start_col,
+                message: format!(
+                    "handler '{handler_name}' has side-effectful steps after an action"
+                ),
+                note: Some(
+                    "an `action` should be the last externally visible step before the \
+                     transition so workflows can resume at a clean checkpoint (#40)"
+                        .to_string(),
+                ),
+            });
+        }
+    }
+
+    // Recurse into branches — each arm is an independent sequence.
+    for stmt in &block.statements {
+        match stmt {
+            Statement::If {
+                then_block,
+                else_block,
+                ..
+            } => {
+                walk_sequence_for_action_safety(
+                    then_block,
+                    handler_name,
+                    handler_span,
+                    actions,
+                    file,
+                    report,
+                );
+                if let Some(else_block) = else_block {
+                    walk_sequence_for_action_safety(
+                        else_block,
+                        handler_name,
+                        handler_span,
+                        actions,
+                        file,
+                        report,
+                    );
+                }
+            }
+            Statement::Match { arms, .. } => {
+                for arm in arms {
+                    walk_sequence_for_action_safety(
+                        &arm.body,
+                        handler_name,
+                        handler_span,
+                        actions,
+                        file,
+                        report,
+                    );
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Classify a statement's top-level side-effect for action-safety analysis.
+/// Expressions embedded in `let` / `return` / `expr` that contain a `perform`
+/// are surfaced via `expr_perform_name` so `let x = perform load(...);` is
+/// classified correctly.
+fn classify_statement_side_effect(stmt: &Statement, actions: &HashSet<String>) -> SideEffectKind {
+    match stmt {
+        Statement::Perform { effect, .. } => {
+            if actions.contains(effect) {
+                SideEffectKind::Action
+            } else {
+                SideEffectKind::Effect
+            }
+        }
+        Statement::Send { .. } | Statement::Spawn { .. } => SideEffectKind::OtherExternal,
+        Statement::Let { value, .. } | Statement::Expr(value) | Statement::Return(value) => {
+            match expr_perform_name(value) {
+                Some(name) if actions.contains(name) => SideEffectKind::Action,
+                Some(_) => SideEffectKind::Effect,
+                None => SideEffectKind::None,
+            }
+        }
+        // Control-flow statements are inspected recursively by the caller; at
+        // this level they carry no direct side effect.
+        Statement::If { .. } | Statement::Match { .. } | Statement::Goto { .. } => {
+            SideEffectKind::None
+        }
+    }
+}
+
+/// If an expression contains a top-level `perform`, return the effect name.
+/// Only matches when the outermost expression (possibly wrapped in trivial
+/// structure) is a `perform`; nested performs inside binops or field access
+/// are intentionally ignored here to avoid conflating incidental expressions
+/// with the handler's primary side-effectful step.
+fn expr_perform_name(expr: &Expr) -> Option<&str> {
+    match expr {
+        Expr::Perform(name, _) => Some(name),
+        _ => None,
     }
 }
 

--- a/gust-lang/tests/action_handler_safety.rs
+++ b/gust-lang/tests/action_handler_safety.rs
@@ -1,0 +1,338 @@
+//! Handler-safety diagnostics for `action` usage (#40 PR 4).
+//!
+//! Two rules, both warnings (additive per the #40 delivery plan):
+//!
+//! 1. A handler should perform at most one `action` per code path.
+//! 2. An `action` should be the last side-effectful step on its path;
+//!    if any `perform`, `send`, or `spawn` follows it, the runtime
+//!    cannot checkpoint cleanly.
+//!
+//! Branches (if/else, match arms) are analyzed as independent sequences
+//! so actions in different branches are not conflated.
+
+use gust_lang::{parse_program_with_errors, validate_program};
+
+fn warnings(source: &str) -> Vec<String> {
+    let program = parse_program_with_errors(source, "t.gu").expect("should parse");
+    let report = validate_program(&program, "t.gu", source);
+    report.warnings.iter().map(|w| w.message.clone()).collect()
+}
+
+fn has_multi_action_warning(warnings: &[String]) -> bool {
+    warnings
+        .iter()
+        .any(|w| w.contains("actions in a single sequence"))
+}
+
+fn has_action_not_last_warning(warnings: &[String]) -> bool {
+    warnings
+        .iter()
+        .any(|w| w.contains("side-effectful steps after an action"))
+}
+
+// ---------------------------------------------------------------------------
+// Rule 1: more than one action per path
+// ---------------------------------------------------------------------------
+
+#[test]
+fn single_action_in_handler_is_ok() {
+    let source = r#"
+machine Notifier {
+    state Idle
+    state Pending(msg: String)
+    state Sent(ts: String)
+
+    transition send: Pending -> Sent
+
+    action post(msg: String) -> String
+
+    on send(ctx: Ctx) {
+        let ts: String = perform post(ctx.msg);
+        goto Sent(ts);
+    }
+}
+"#;
+    let w = warnings(source);
+    assert!(
+        !has_multi_action_warning(&w),
+        "single action should not warn about multi-action, got: {:?}",
+        w
+    );
+}
+
+#[test]
+fn two_actions_in_handler_warns() {
+    let source = r#"
+machine DualNotifier {
+    state Idle
+    state Pending(a: String, b: String)
+    state Sent(ts: String)
+
+    transition send: Pending -> Sent
+
+    action post_a(msg: String) -> String
+    action post_b(msg: String) -> String
+
+    on send(ctx: Ctx) {
+        let ts1: String = perform post_a(ctx.a);
+        let ts2: String = perform post_b(ctx.b);
+        goto Sent(ts2);
+    }
+}
+"#;
+    let w = warnings(source);
+    assert!(
+        has_multi_action_warning(&w),
+        "two actions in one handler should warn, got warnings: {:?}",
+        w
+    );
+}
+
+#[test]
+fn action_and_effect_together_is_ok() {
+    let source = r#"
+machine Mixed {
+    state Start
+    state Done(ts: String)
+
+    transition go: Start -> Done
+
+    effect compute() -> String
+    action publish(v: String) -> String
+
+    on go() {
+        let a: String = perform compute();
+        let ts: String = perform publish(a);
+        goto Done(ts);
+    }
+}
+"#;
+    let w = warnings(source);
+    assert!(
+        !has_multi_action_warning(&w),
+        "one effect + one action should not trigger multi-action warning, got: {:?}",
+        w
+    );
+    assert!(
+        !has_action_not_last_warning(&w),
+        "action is last side-effect here, should not warn, got: {:?}",
+        w
+    );
+}
+
+#[test]
+fn actions_in_different_branches_are_independent() {
+    let source = r#"
+machine Router {
+    state Start(cond: bool)
+    state Done(v: String)
+
+    transition go: Start -> Done
+
+    action path_a() -> String
+    action path_b() -> String
+
+    on go(ctx: Ctx) {
+        if ctx.cond {
+            let v: String = perform path_a();
+            goto Done(v);
+        } else {
+            let v: String = perform path_b();
+            goto Done(v);
+        }
+    }
+}
+"#;
+    let w = warnings(source);
+    assert!(
+        !has_multi_action_warning(&w),
+        "actions in separate branches should not trigger multi-action warning, got: {:?}",
+        w
+    );
+}
+
+#[test]
+fn two_actions_in_same_branch_warns() {
+    let source = r#"
+machine Router {
+    state Start(cond: bool)
+    state Done(v: String)
+
+    transition go: Start -> Done
+
+    action a() -> String
+    action b() -> String
+
+    on go(ctx: Ctx) {
+        if ctx.cond {
+            let x: String = perform a();
+            let y: String = perform b();
+            goto Done(y);
+        } else {
+            goto Done("skip");
+        }
+    }
+}
+"#;
+    let w = warnings(source);
+    assert!(
+        has_multi_action_warning(&w),
+        "two actions in the same branch should warn, got: {:?}",
+        w
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Rule 2: action must be the last side-effectful step
+// ---------------------------------------------------------------------------
+
+#[test]
+fn action_followed_by_effect_warns() {
+    let source = r#"
+machine Misordered {
+    state Start
+    state Done(v: String)
+
+    transition go: Start -> Done
+
+    action publish(v: String) -> String
+    effect log(msg: String) -> String
+
+    on go() {
+        let a: String = perform publish("hi");
+        let b: String = perform log("after");
+        goto Done(b);
+    }
+}
+"#;
+    let w = warnings(source);
+    assert!(
+        has_action_not_last_warning(&w),
+        "action followed by effect should warn, got: {:?}",
+        w
+    );
+}
+
+#[test]
+fn action_followed_by_send_warns() {
+    let source = r#"
+channel audit: String (mode: broadcast)
+
+machine Misordered (sends audit) {
+    state Start
+    state Done(v: String)
+
+    transition go: Start -> Done
+
+    action publish(v: String) -> String
+
+    on go() {
+        let a: String = perform publish("hi");
+        send audit("after");
+        goto Done(a);
+    }
+}
+"#;
+    let program = parse_program_with_errors(source, "t.gu").expect("should parse");
+    let report = validate_program(&program, "t.gu", source);
+    let ws: Vec<String> = report.warnings.iter().map(|w| w.message.clone()).collect();
+    assert!(
+        has_action_not_last_warning(&ws),
+        "action followed by send should warn, got: {:?}",
+        ws
+    );
+}
+
+#[test]
+fn action_as_last_side_effect_is_ok() {
+    let source = r#"
+machine CleanOrder {
+    state Start
+    state Done(v: String)
+
+    transition go: Start -> Done
+
+    effect prep() -> String
+    action publish(v: String) -> String
+
+    on go() {
+        let pre: String = perform prep();
+        let v: String = perform publish(pre);
+        goto Done(v);
+    }
+}
+"#;
+    let w = warnings(source);
+    assert!(
+        !has_action_not_last_warning(&w),
+        "action as last side-effect should not warn, got: {:?}",
+        w
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Machines without any `action` declarations must not see these warnings
+// ---------------------------------------------------------------------------
+
+#[test]
+fn effect_only_machine_never_warns_about_actions() {
+    let source = r#"
+machine OnlyEffects {
+    state Start
+    state Done(v: String)
+
+    transition go: Start -> Done
+
+    effect a() -> String
+    effect b() -> String
+    effect c() -> String
+
+    on go() {
+        let x: String = perform a();
+        let y: String = perform b();
+        let z: String = perform c();
+        goto Done(z);
+    }
+}
+"#;
+    let w = warnings(source);
+    assert!(
+        !has_multi_action_warning(&w),
+        "effect-only machine should never trigger action multi-warning"
+    );
+    assert!(
+        !has_action_not_last_warning(&w),
+        "effect-only machine should never trigger action-not-last warning"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// `perform` inside a `let` / return / expression statement still counts
+// ---------------------------------------------------------------------------
+
+#[test]
+fn perform_in_let_value_counts_as_action() {
+    let source = r#"
+machine Letter {
+    state Start
+    state Done(v: String)
+
+    transition go: Start -> Done
+
+    action publish(v: String) -> String
+    effect log(msg: String) -> String
+
+    on go() {
+        let v: String = perform publish("hi");
+        let m: String = perform log("after");
+        goto Done(v);
+    }
+}
+"#;
+    let w = warnings(source);
+    assert!(
+        has_action_not_last_warning(&w),
+        "perform in let RHS should participate in rule 2 ordering, got: {:?}",
+        w
+    );
+}


### PR DESCRIPTION
## Summary

Final deliverable for #40. Two new warnings catch replay-unsafe patterns in handlers that mix `effect` and `action`:

### Rule 1 — at most one action per code path

A handler should perform at most one `action` per linear statement sequence. More than one action in the same path makes workflow checkpointing ambiguous. **Warning**, not error.

Branches (if/else, match arms) count as independent paths, so `action` in one branch and another in a sibling branch does not trigger the rule.

### Rule 2 — action must be the last side-effectful step

If any `perform` (effect or action), `send`, or `spawn` follows an `action` on the same path before the handler transitions, the runtime cannot checkpoint at a clean boundary. **Warning** with guidance to reorder.

## Resolves open questions from the plan

From the implementation plan comment on #40:

> 2. **`action` within a `match` arm**: does "last side-effectful step" require it to be in the terminal arm, or just the terminal step of whichever arm the runtime takes?

**Answered**: terminal step of whichever arm. Each arm is analyzed as its own linear sequence. Rationale: the runtime only takes one arm at a time, so the checkpoint boundary is per-arm.

> 3. **Stricter rule for errors later**: is the eventual target "exactly one action per handler"? Or "at most one action, and it must be last"?

**Implemented as**: "at most one action, and it must be last" — per code path. Still at warning level in this PR; can be promoted to error in a future release once Corsac's workflows have adjusted.

## Design

- New `SideEffectKind` enum classifies each statement's top-level side effect (None / Effect / Action / OtherExternal).
- `check_handler_action_safety` walks the handler body; each block is analyzed as an independent sequence, branches recurse.
- `perform` calls inside `let` / `return` / `expr` statements still count as that statement's side effect via `expr_perform_name`.
- `declared_actions: HashSet<String>` is built once per machine from `EffectKind::Action`; machines with no actions short-circuit.

## Compatibility

Warnings only. No existing program breaks. Machines that don't declare any `action` skip the check entirely.

## Test Plan

- [x] 10 new tests in `gust-lang/tests/action_handler_safety.rs`
- [x] `cargo test --workspace --all-targets --all-features` — no regressions
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`

### Test coverage

**Rule 1**:
- single action → OK
- two actions in one handler → warning
- one effect + one action → no warning (only action counts)
- actions in separate branches → no warning (independent paths)
- two actions in the same branch → warning

**Rule 2**:
- action followed by effect → warning
- action followed by `send` → warning
- action as last side-effect → no warning

**Neutral**:
- effect-only machine never triggers either warning
- `perform` inside a `let` RHS still participates in ordering

## Closes the #40 series

| PR | Deliverable |
|---|---|
| #47 | `EngineFailure` in stdlib |
| #48 | `action` keyword in parser/AST |
| #49 | Codegen + MCP surface the distinction |
| this | Handler-safety diagnostics |

Closes #40.

---
Generated with [Claude Code](https://claude.ai/code)