### PR TITLE
docs: reflect #30 + #40 shipping + add long-term roadmap horizon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,75 @@ All notable changes to the Gust project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`action` keyword** (#40) — non-idempotent / externally visible counterpart
+  to `effect`. Grammar, AST (`EffectKind::{Effect, Action}`), parser,
+  formatter, codegen (rustdoc + Go `//` markers), and MCP (`kind` field on
+  effects) all preserve the distinction. Replay-aware workflow runtimes
+  (Corsac) consume `kind` to drive retry and checkpoint semantics.
+- **Handler-safety diagnostics for actions** (#40) — two new warnings:
+  (1) at most one `action` per code path; (2) an `action` must be the last
+  side-effectful step before a transition.
+- **`EngineFailure` in `gust-stdlib`** (#40) — typed runtime failure enum
+  (`UserError`, `SystemError`, `IntegrationError`, `Timeout`, `Cancelled`)
+  for workflow contracts. Importable via `use std::EngineFailure;`.
+- **Goto field type validation** (#30) — `goto` argument types are checked
+  against target state field types with conservative inference (unknown
+  types skip the check rather than emitting a false positive).
+- **Effect return type checking** (#30) — `let x: T = perform e(...)` is
+  rejected when `T` doesn't match `e`'s declared return type.
+- **If/else branch termination consistency** (#30) — warns when one branch
+  of an `if/else` terminates and the other falls through.
+- **Binary operator operand compatibility** (#30) — warns when a `BinOp`'s
+  two operands resolve to incompatible concrete types.
+- **Match exhaustiveness diagnostics** (#43) — warns on non-exhaustive
+  `match` over known enums; exhaustive matches count as termination for
+  handler fall-through analysis.
+- **Effect argument arity validation** (#42) — `perform` invocations are
+  checked against the effect's declared parameter count.
+- **JSON Schema codegen** (#35) — `--target schema` / `gust schema` emits
+  JSON Schema from types and machine states.
+- **Optional tracing instrumentation** (#32) — `RustCodegen::with_tracing(true)`
+  emits `tracing::info!` events guarded by a `tracing` feature flag.
+- **`gust doctor`** (#27) — environment diagnostics for rustc, cargo, Go
+  toolchains, project layout, and `.gu` file freshness.
+- **Test coverage expansion** — unit tests for `gust-runtime` (45 tests),
+  stdlib machines (121 tests), MCP integration (51 tests), LSP integration
+  (85 tests), CLI integration (29 tests), build-script helper (31 tests),
+  formatter roundtrip (12 tests), codegen edge cases (14 tests), and
+  comprehensive diagnostics coverage (56 validator tests).
+
+### Changed
+
+- **Source span tracking** (#13) — the validator now uses AST-carried
+  `Span` values directly instead of the fragile `SourceLocator` string
+  search. Replaces a known limitation called out in CLAUDE.md.
+- **MCP `gust_parse` output** — effect entries now include a `kind` field
+  (`"effect"` or `"action"`) alongside `name`, `params`, `return_type`,
+  and `is_async`.
+- **Stdlib `all_sources()`** now returns 7 entries (adds `engine_failure.gu`).
+- **Clippy 1.95 compatibility** (#41) — collapsed nested match-arm guards
+  to satisfy the stricter `collapsible_match` lint.
+
+### Fixed
+
+- **Build-script error handling** (#21) — replaced `unwrap()` with descriptive
+  `expect()` messages throughout the test suite and expanded coverage to
+  all five codegen targets.
+
+### Known limitations (tracked as follow-ups)
+
+- Diagnostics from item 3 (if/else branch termination) and item 4 (binary
+  operator operand compatibility) of the handler type-checking series fall
+  back to `line: 0, col: 0` because `Statement::If` and `Expr::BinOp` don't
+  yet carry spans. Tracked in issue #46.
+- Gust enum variants support positional payloads only (e.g.
+  `Variant(String, i64)`), not named fields. The `EngineFailure` type in
+  the stdlib is documented with position meanings in its `.gu` source.
+
 ## [0.1.0] - 2025-06-15
 
 Initial public release of Gust, a type-safe state machine language that compiles

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,10 @@ Pipeline: `source.gu → Parser (pest PEG) → AST → Validator → Codegen →
 - **Generated file extension**: `.g.rs` / `.g.go` (inspired by C# source generators). These files should never be manually edited.
 - **Effect traits**: Each machine with effects generates a `{Machine}Effects` trait. Transition methods take `effects: &impl {Machine}Effects`.
 - **Goto field mapping**: Arguments to `goto` are positionally zipped with the target state's declared fields.
-- **AST nodes carry `Span`** (start/end line+col) captured from pest during parsing. The validator uses these spans for all diagnostics.
+- **AST nodes carry `Span`** (start/end line+col) captured from pest during parsing. The validator uses these spans for all diagnostics. Currently only top-level nodes (declarations, `goto`, `perform`, `send`, `spawn`) carry spans; expression nodes fall back to default spans (tracked in issue #46).
+- **`effect` vs `action`**: `EffectDecl` carries an `EffectKind` enum (`Effect` / `Action`). Both share the same syntactic shape and codegen lowering — the distinction lives in one field. Replay-aware runtimes (Corsac) consume it via the `kind` field in MCP `gust_parse` output and the generated doc markers. Validator emits warnings for >1 action per code path and for actions that aren't the last side-effectful step before a transition (#40).
+- **Conservative type inference**: the validator's `TypeContext` infers expression types for goto-arg / let-annotation / binop-operand checks, but treats unknown types (e.g. plain function-call returns) as "skip the check" rather than reporting a false positive. Generic type parameters are treated as compatible with any type.
+- **Enum variant payloads are positional** — the grammar supports `enum Foo { Bar(String, i64) }` but not named fields. This is the current limitation that shaped the `EngineFailure` stdlib type.
 - **LSP rename/find-references disabled** in v0.1.0 until symbol resolution is scope-aware.
 - **Examples are excluded** from the workspace (`exclude = ["examples/*"]` in root `Cargo.toml`) and must be tested via explicit `--manifest-path`.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,12 @@
 # Gust Roadmap
 
-This roadmap covers the remaining work to make Gust production-ready across the compiler, LSP, VS Code extension, and AI tooling. Items are ordered by dependency and daily-use impact.
+This roadmap has two horizons.
+
+**Near-term (Phases 1–5):** production-readiness for Gust as it exists today — a state machine language. Polish the compiler, LSP, tooling, and AI integration.
+
+**Long-term (Phases 6+):** evolve Gust from a state machine DSL into a general-purpose language. Machines remain a first-class construct, but Gust grows to support free functions, module-level code, contracts, and its own type/effect system. Each phase is independently shippable — no phase blocks on a subsequent one, and Gust-as-DSL remains valid at every step.
+
+Items are ordered by dependency and daily-use impact.
 
 ---
 
@@ -12,6 +18,16 @@ These are correctness and ergonomics issues in the core toolchain.
 - [x] **Handler coverage check** — warn when a transition is declared but has no corresponding `on` handler
 - [x] **Multi-machine diagram** — `gust diagram` now supports `--machine NAME` flag and emits all machines when no flag is given
 - [x] **Source span tracking** — replace string-search source location in the validator with actual span data from the parser (fragile on duplicate identifiers)
+- [x] **Effect argument arity validation** — `perform` invocations type-checked against effect declaration arity
+- [x] **Match exhaustiveness diagnostics** — warn on non-exhaustive matches over known enums; exhaustive matches count as termination
+- [x] **Goto field type validation** — check `goto` arguments against target state field types with conservative inference
+- [x] **Handler expression type checking** — effect return-type annotations, if/else branch termination consistency, binary operator operand compatibility
+- [x] **`action` keyword for non-idempotent operations** — `EffectKind::Action` in AST/codegen/MCP + handler-safety diagnostics for workflow runtimes (#40)
+- [x] **`EngineFailure` in stdlib** — typed runtime failure enum for workflow contracts (#40)
+- [x] **`gust doctor` subcommand** — environment diagnostics (rustc/cargo/go/project layout/`.gu` freshness)
+- [x] **JSON Schema codegen** — `--target schema` / `gust schema` emits JSON Schema from types and machine states
+- [x] **Optional tracing codegen** — `RustCodegen::with_tracing(true)` emits `tracing::info!` events guarded by a `tracing` feature flag
+- [ ] **Expression-level source spans** — extend span tracking to `Statement::If`, `Statement::Match`, `Statement::Let`, and all `Expr::*` nodes so validator diagnostics don't fall back to line 0, col 0 (#46)
 - [ ] **`gust test` subcommand** — unit-test machines with mock effects; define test cases in `.gu` or a companion `.gu.test` file
 - [ ] **Multi-file type resolution** — allow `use` declarations to pull types from other `.gu` files in the same project
 
@@ -76,9 +92,93 @@ Expose the Gust compiler as MCP tools so any AI assistant with MCP support can c
 
 ---
 
+## Phase 6 — General-Purpose Core
+
+The fork in the road. After this phase, machines are one construct among many. A `.gu` file can compile and run without declaring a single machine.
+
+Ordering matters here: the first item gates all the others.
+
+- [ ] **Top-level `fn` declarations** — add `fn_decl` as a valid top-level item in `grammar.pest` alongside `use_decl`, `type_decl`, `channel_decl`, `machine_decl`. This is the single grammar change that stops Gust from being a DSL.
+- [ ] **Standalone modules** — a `.gu` file with no machines parses, validates, and compiles to a usable library module.
+- [ ] **Top-level `const` and `let`** — module-level immutable bindings for constants and shared values.
+- [ ] **Expression-bodied functions** — `fn add(a: i32, b: i32) -> i32 = a + b;`. Reduces ceremony for single-expression functions, matches existing `perform` expression semantics.
+- [ ] **Block expressions** — `{ ... }` blocks evaluate to their final expression. Enables `let x = { let tmp = compute(); tmp * 2 };` and multi-line expression bodies.
+- [ ] **`Option<T>` and `Result<T, E>` as built-in types** — currently expressible as user enums. Built-in forms get first-class pattern syntax, codegen specialization, and standard library support.
+- [ ] **`main()` entry point** — when a module defines `fn main()`, codegen emits an executable binary, not just a library.
+
+---
+
+## Phase 7 — Expression-Oriented Flow
+
+Control flow as values. This phase makes Gust feel like an expression-oriented language in the mold of Rust, Kotlin, and F#. Read-at-2-AM syntax pays off here.
+
+- [ ] **`if` as expression** — `let x = if cond { a } else { b };` produces a value. Both branches must type-unify.
+- [ ] **`match` as expression (outside machines)** — already a statement inside machines; lift to general use and allow it to produce values.
+- [ ] **Inline error matching at call sites** — the distinctive Gust syntax: bind and match in a single construct. `let u = db.find(id) { ok(u) -> u; not_found -> default_user; err(e) -> panic(e) };` — replaces the separate `let` + `match` two-step. Needs explicit grammar design to avoid ambiguity with block bodies.
+- [ ] **Error propagation operator** — decide explicitly: support `?`-style short-circuit, or force inline matching everywhere. Implications for readability in deep error paths.
+- [ ] **Destructuring patterns in `let` and parameters** — `let { name, age } = user;` and `fn greet({ name }: User) = ...`.
+- [ ] **Guards in match arms** — `n if n > 0 => ...` for range and predicate matching.
+
+---
+
+## Phase 8 — Mutation Semantics
+
+Make mutation visible, bounded, and deterministic. This is a semantic change with syntactic consequences, not the other way around. Several decisions here need to be made *before* any code is written.
+
+- [ ] **Immutability by default for `let`** — current `let` inherits the host language's rules. Gust needs its own stance: bindings are immutable unless introduced in a `mut` context.
+- [ ] **`mut` blocks with lexical scope** — `mut counter { counter += 1 }`. Outside the block, the binding is frozen again. Enforced by the validator, not just convention.
+- [ ] **Decide: aliasing rules inside `mut`** — Rust-style exclusive access (soundness), or permissive with runtime checks (ergonomics). This decision shapes every subsequent concurrency guarantee.
+- [ ] **Decide: can values escape a `mut` block?** — can a `mut` block produce a value used outside it? If yes, how is the mutation prevented from leaking? Options: rank-2 types (Haskell ST), relying on Rust's borrow checker through codegen, or forbidding escape entirely.
+- [ ] **Interior mutability escape hatch** — explicit opt-in for memoization, lazy fields, and other observationally-pure mutation.
+- [ ] **I/O story** — document the rule: does `println` require a `mut` block? If yes, consistent but ceremonial. If no, principled exception needed. Either answer is defensible; silence is not.
+- [ ] **Codegen for `mut`** — Rust target maps cleanly (`let mut` inside the block). Go target needs explicit handling since Go has no equivalent concept.
+
+---
+
+## Phase 9 — Contracts
+
+Runtime-checked first. Compile-time proving is a later research track (Phase 11). The goal here is to make contracts part of the language, not a library.
+
+- [ ] **`require` / `ensure` on function signatures** — preconditions and postconditions as part of the declaration, not doc comments. Visible in hover, signature help, generated docs.
+- [ ] **Runtime contract generation** — codegen emits assertion guards at the start and end of function bodies. Rust target uses `assert!`; Go target uses `panic` with explicit messages.
+- [ ] **`where` clauses on types** — refinement types: `type PositiveInt = i32 where self > 0`. Validated on construction.
+- [ ] **Contract-aware serialization** — deserializing a type validates its contracts, not just its shape. Invalid JSON → typed error, not a runtime surprise 20 lines later.
+- [ ] **`assume` escape hatch** — for contracts that cannot or should not be checked at a particular call site. Explicit, auditable, greppable.
+- [ ] **Documentation from contracts** — `gust doc` surfaces `require`/`ensure` as part of the public API. Contracts are specification, not implementation.
+- [ ] **Contract inheritance rules** — what happens when a refined type is used in a struct field? Nested contracts compose or conflict; the rule needs to be explicit.
+
+---
+
+## Phase 10 — Type System & Effects
+
+Extend the existing effect system beyond machines and start owning type-checking instead of delegating to the target language. This is where Gust stops being a transpiler and becomes a compiler with a backend.
+
+- [ ] **Effects on free functions** — `effect` is currently a machine-local concept. Free functions need the same first-class effect declarations.
+- [ ] **Effect polymorphism for higher-order functions** — a `map` function that's polymorphic over the callback's effects. Without this, the standard library needs N copies of every combinator (sync/async/fallible/mutating). Koka and Roc are the reference models.
+- [ ] **Own type checker** — stop relying on Rust/Go type errors surfacing through generated code. Diagnostics should point at `.gu` source, not generated `.g.rs`.
+- [ ] **Type inference** — bidirectional inference for the 80% case; explicit annotations at module boundaries and public API surfaces.
+- [ ] **Opaque / branded types** — nominal escape hatch from the structural default. `opaque type UserId = UUID;` makes `UserId` and `OrderId` incompatible even when the underlying representations match.
+- [ ] **Trait bounds on generics wired end-to-end** — grammar already supports `T: Bound1 + Bound2`; validator and codegen need to enforce the bound instead of passing it through.
+- [ ] **Effect handlers (resumable continuations)** — current `perform` delegates to a host-language trait impl. True effect handlers enable algebraic effects: a caller can catch, transform, or resume an effect mid-flight. Significant codegen work.
+
+---
+
+## Phase 11 — Research Track (long-horizon)
+
+Explicitly framed as research, not a shipping commitment. Do not block other phases on these. Most of these are multi-year investments with uncertain outcomes.
+
+- [ ] **SMT integration (Z3)** — compile-time proving of decidable contract fragments (arithmetic bounds, null-safety, simple invariants). Define the decidable syntactic subset explicitly; everything outside falls back to runtime.
+- [ ] **Dependent contracts** — `List<T> where len(self) >= 1`, where the contract depends on a runtime value. Expressive but hard to infer and prove.
+- [ ] **Property-based testing from contracts** — generate QuickCheck-style tests automatically from `require`/`ensure`. Low-hanging fruit once contracts exist.
+- [ ] **Formal verification mode** — opt-in per module flag; all contracts must be proved statically or compilation fails. Reference: Dafny, F*, SPARK.
+- [ ] **Ownership inference** — infer Rust-style borrow relationships from usage patterns without requiring lifetime annotations in `.gu` source. Not a solved problem; research-grade work.
+- [ ] **Incremental compilation** — only recheck/regenerate what changed. Becomes critical once the type checker and contract prover get expensive.
+
+---
+
 ## Remaining
 
-- [x] Source span tracking (Phase 1) — parser spans instead of string search
+- [ ] Expression-level source spans (Phase 1, #46) — spans on `Statement::If`, `Statement::Match`, `Statement::Let`, `Expr::*`
 - [ ] `gust test` subcommand (Phase 1) — mock effects, test runner
 - [ ] Multi-file type resolution (Phase 1) — cross-file `use` declarations
 - [ ] Cross-file go-to-definition (Phase 2) — LSP follows `use` imports
@@ -90,15 +190,19 @@ Expose the Gust compiler as MCP tools so any AI assistant with MCP support can c
 ## Done
 
 - [x] Core grammar and parser (`grammar.pest`, `ast.rs`, `parser.rs`)
-- [x] Rust codegen (`codegen.rs`) — full target including async, generics, FFI
+- [x] Rust codegen (`codegen.rs`) — full target including async, generics, FFI, optional tracing instrumentation
 - [x] Go codegen (`codegen_go.rs`) — interfaces, unit effects, async effects
 - [x] WASM and no_std codegens
+- [x] JSON Schema codegen — types + machine states to JSON Schema
 - [x] Formatter (`format.rs`)
-- [x] Validator — duplicate names, unreachable states, unknown effects, goto arity, ctx field access, send/spawn targets, typo suggestions, **exhaustive goto check, handler coverage**
-- [x] CLI — `build`, `check`, `fmt`, `diagram` (multi-machine), `watch`, `init`, `parse`
+- [x] Validator — duplicate names, unreachable states, unknown effects, goto arity + **goto field type validation**, ctx field access, send/spawn targets, typo suggestions, **exhaustive goto check**, **handler coverage**, **effect argument arity**, **match exhaustiveness**, **effect return type checking on let annotations**, **if/else branch termination consistency**, **binary operator operand compatibility**, **handler-safety diagnostics for `action`**
+- [x] Source span tracking — top-level nodes carry `Span` captured from pest
+- [x] `effect` vs `action` distinction — `EffectKind` on `EffectDecl`, formatter roundtrip, codegen doc markers (Rust rustdoc + Go `//`), MCP `kind` field
+- [x] CLI — `build`, `check`, `fmt`, `diagram` (multi-machine), `watch`, `init`, `parse`, **`doctor`**, **`schema`**
 - [x] `-> ()` unit type support
 - [x] LSP — diagnostics, hover (states, effects, transitions, types), go-to-definition, completions, **formatting, documentSymbol, signatureHelp, rename, references, code actions, inlay hints**
 - [x] VS Code extension — syntax highlighting, snippets (10 total), file icon, LSP client, file nesting, **commands (diagram/check/format), status bar**
-- [x] MCP server (`gust-mcp`) — 5 tools: check, build, diagram, format, parse
+- [x] MCP server (`gust-mcp`) — 5 tools: check, build, diagram, format, parse (now with `kind` on effects)
 - [x] Claude Code plugin — 3 commands, 1 skill, 1 agent, drop-in GUST.md
+- [x] Standard library — `CircuitBreaker`, `Retry`, `Saga`, `RateLimiter`, `HealthCheck`, `RequestResponse` machines + `EngineFailure` type (Corsac workflow contract)
 - [x] Corsac architecture documentation (`D:/Dev/go/corsac/docs/`)


### PR DESCRIPTION
## Summary

Doc-only PR updating `ROADMAP.md`, `CLAUDE.md`, and `CHANGELOG.md` to reflect what landed during the April 2026 cleanup session.

## ROADMAP.md

- **Phase 1 completions**: source spans (#13), effect arity (#42), match exhaustiveness (#43), goto field type validation + handler expression type checking (#44, #45), `action` keyword + handler safety (#40 series), `EngineFailure` stdlib, `gust doctor`, JSON Schema codegen, tracing codegen.
- **Two-horizon framing**: near-term (Phases 1–5) polishes Gust-as-DSL; long-term (Phases 6+) evolves it into a general-purpose language.
- **Phases 6–11 sketch**: General-Purpose Core, Expression-Oriented Flow, Mutation Semantics, Contracts, Type System & Effects, Research Track.

## CLAUDE.md

Architecture section now documents:
- `EffectKind` design (single field, not parallel AST types)
- Conservative type-inference policy (unknown → skip, not false-positive)
- Enum-variant positional-only limitation (shaped `EngineFailure`)
- Current span coverage + the #46 follow-up for expression-level spans

## CHANGELOG.md

New `[Unreleased]` section lists every added/changed/fixed item since 0.1.0 with PR references.

## Test Plan

- [x] `cargo test --workspace` — no regressions
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`

Docs-only — no code changes.

---
Generated with [Claude Code](https://claude.ai/code)