### PR TITLE
test(codegen): raise WASM and no_std coverage to ~97%

### DIFF
--- a/gust-lang/tests/nostd_codegen_coverage.rs
+++ b/gust-lang/tests/nostd_codegen_coverage.rs
@@ -168,7 +168,9 @@ machine Container<T> {
 
 #[test]
 fn default_impl_equivalent_to_new() {
-    let a = NoStdCodegen::default();
+    // Route through the Default trait explicitly — see wasm counterpart
+    // for the clippy 1.95 reasoning.
+    let a: NoStdCodegen = Default::default();
     let b = NoStdCodegen::new();
     let src = "machine M { state S }";
     let program = parse_program_with_errors(src, "t.gu").expect("parses");

--- a/gust-lang/tests/nostd_codegen_coverage.rs
+++ b/gust-lang/tests/nostd_codegen_coverage.rs
@@ -1,0 +1,198 @@
+//! Branch-level coverage for `codegen_nostd.rs`.
+//!
+//! Complements `target_backends.rs` by exercising: state with and
+//! without fields, constructors for both shapes, transitions from
+//! field-bearing states (`{ .. }` pattern), generic machines, and
+//! every arm of the `nostd_type` mapping (Vec/Option/Result/other
+//! generic, tuple, primitives, unknown Simple, Unit).
+
+use gust_lang::{parse_program_with_errors, NoStdCodegen};
+
+fn gen(source: &str) -> String {
+    let program = parse_program_with_errors(source, "test.gu").expect("source should parse");
+    NoStdCodegen::new().generate(&program)
+}
+
+#[test]
+fn empty_state_generates_empty_constructor() {
+    let src = r#"
+machine Light {
+    state Off
+    state On
+}
+"#;
+    let out = gen(src);
+    assert!(out.contains("pub fn new() -> Self"));
+    assert!(out.contains("Self { state: LightState::Off }"));
+}
+
+#[test]
+fn field_bearing_first_state_generates_parameterised_constructor() {
+    let src = r#"
+machine Dev {
+    state Idle(name: String, count: i64)
+    state Active
+}
+"#;
+    let out = gen(src);
+    assert!(out.contains("pub fn new(name: HString<64>, count: i64) -> Self"));
+    assert!(out.contains("DevState::Idle { name, count }"));
+}
+
+#[test]
+fn transitions_from_field_bearing_states_use_struct_pattern() {
+    let src = r#"
+machine Dev {
+    state Idle(name: String)
+    state Active
+    transition go: Idle -> Active
+    on go() { goto Active(); }
+}
+"#;
+    let out = gen(src);
+    assert!(out.contains("DevState::Idle { .. }"));
+    assert!(out.contains("self.state = DevState::Active"));
+}
+
+#[test]
+fn transitions_from_empty_states_use_bare_pattern() {
+    let src = r#"
+machine Door {
+    state Closed
+    state Open
+    transition open: Closed -> Open
+    on open() { goto Open(); }
+}
+"#;
+    let out = gen(src);
+    assert!(out.contains("DoorState::Closed =>"));
+    // Should NOT contain the `{ .. }` pattern form.
+    assert!(!out.contains("DoorState::Closed {"));
+}
+
+#[test]
+fn vec_type_maps_to_hvec() {
+    let src = r#"
+machine Buf {
+    state Holding(items: Vec<i64>)
+}
+"#;
+    let out = gen(src);
+    assert!(out.contains("items: HVec<i64, 16>"));
+}
+
+#[test]
+fn option_type_preserves_option_wrapper() {
+    let src = r#"
+machine Box {
+    state Filled(value: Option<i64>)
+}
+"#;
+    let out = gen(src);
+    assert!(out.contains("value: Option<i64>"));
+}
+
+#[test]
+fn result_type_preserves_both_arms() {
+    let src = r#"
+machine Outcome {
+    state Done(value: Result<i64, String>)
+}
+"#;
+    let out = gen(src);
+    // Inner String maps to HString<64> in the nostd mapping.
+    assert!(out.contains("value: Result<i64, HString<64>>"));
+}
+
+#[test]
+fn unknown_generic_passes_through_with_mapped_args() {
+    let src = r#"
+machine Holder {
+    state Holding(val: Custom<i64, String>)
+}
+"#;
+    let out = gen(src);
+    assert!(out.contains("val: Custom<i64, HString<64>>"));
+}
+
+#[test]
+fn tuple_type_flattened() {
+    let src = r#"
+machine Pair {
+    state Holding(p: (i64, String, bool))
+}
+"#;
+    let out = gen(src);
+    assert!(out.contains("p: (i64, HString<64>, bool)"));
+}
+
+#[test]
+fn unknown_simple_type_passes_through() {
+    let src = r#"
+machine Mystery {
+    state Holding(val: MyCustomType)
+}
+"#;
+    let out = gen(src);
+    assert!(out.contains("val: MyCustomType"));
+}
+
+#[test]
+fn all_primitive_types_preserved() {
+    let src = r#"
+machine Prim {
+    state Holding(a: i32, b: u32, c: u64, d: f32, e: f64, f: bool)
+}
+"#;
+    let out = gen(src);
+    for pat in ["a: i32", "b: u32", "c: u64", "d: f32", "e: f64", "f: bool"] {
+        assert!(out.contains(pat), "missing {pat} in output:\n{out}");
+    }
+}
+
+#[test]
+fn generic_machine_emits_clone_bound() {
+    let src = r#"
+machine Container<T> {
+    state Empty
+    state Full
+    transition fill: Empty -> Full
+    on fill() { goto Full(); }
+}
+"#;
+    let out = gen(src);
+    assert!(out.contains("T: Clone"));
+    assert!(out.contains("impl<T: Clone> Container<T>"));
+    assert!(out.contains("pub enum ContainerState<T: Clone>"));
+}
+
+#[test]
+fn default_impl_equivalent_to_new() {
+    let a = NoStdCodegen::default();
+    let b = NoStdCodegen::new();
+    let src = "machine M { state S }";
+    let program = parse_program_with_errors(src, "t.gu").expect("parses");
+    assert_eq!(a.generate(&program), b.generate(&program));
+}
+
+#[test]
+fn prelude_always_emitted() {
+    let out = gen("machine M { state S }");
+    assert!(out.contains("#![no_std]"));
+    assert!(out.contains("extern crate alloc;"));
+    assert!(out.contains("use heapless::{String as HString, Vec as HVec};"));
+}
+
+#[test]
+fn transition_returns_err_on_invalid_state() {
+    let src = r#"
+machine Door {
+    state Closed
+    state Open
+    transition open: Closed -> Open
+    on open() { goto Open(); }
+}
+"#;
+    let out = gen(src);
+    assert!(out.contains("_ => Err(\"invalid transition\")"));
+}

--- a/gust-lang/tests/wasm_codegen_coverage.rs
+++ b/gust-lang/tests/wasm_codegen_coverage.rs
@@ -1,0 +1,172 @@
+//! Branch-level coverage for `codegen_wasm.rs`.
+//!
+//! Complements `target_backends.rs` (which covers the happy path) by
+//! exercising: struct + enum type decls, primitive and composite type
+//! mappings, sync vs timeout transitions, generic machines, and
+//! `Default::default()`.
+
+use gust_lang::{parse_program_with_errors, WasmCodegen};
+
+fn gen(source: &str) -> String {
+    let program = parse_program_with_errors(source, "test.gu").expect("source should parse");
+    WasmCodegen::new().generate(&program)
+}
+
+#[test]
+fn struct_type_decl_emits_wasm_bindgen_struct() {
+    let src = r#"
+type Point { x: i64, y: i64 }
+
+machine M {
+    state S
+}
+"#;
+    let out = gen(src);
+    assert!(out.contains("pub struct Point"));
+    assert!(out.contains("pub x: i64"));
+    assert!(out.contains("pub y: i64"));
+}
+
+#[test]
+fn enum_type_decl_emits_repr_u32_enum_with_indices() {
+    let src = r#"
+enum Color { Red, Green, Blue }
+
+machine M {
+    state S
+}
+"#;
+    let out = gen(src);
+    assert!(out.contains("pub enum Color"));
+    assert!(out.contains("Red = 0"));
+    assert!(out.contains("Green = 1"));
+    assert!(out.contains("Blue = 2"));
+    assert!(out.contains("#[repr(u32)]"));
+}
+
+#[test]
+fn primitive_type_mappings_preserved() {
+    // wasm_type maps i32/u32/u64/f32/f64/bool/String directly; unknown → JsValue.
+    let src = r#"
+type Bag { a: i32, b: u32, c: u64, d: f32, e: f64, f: bool, g: String, h: Custom }
+
+machine M {
+    state S
+}
+"#;
+    let out = gen(src);
+    assert!(out.contains("pub a: i32"));
+    assert!(out.contains("pub b: u32"));
+    assert!(out.contains("pub c: u64"));
+    assert!(out.contains("pub d: f32"));
+    assert!(out.contains("pub e: f64"));
+    assert!(out.contains("pub f: bool"));
+    assert!(out.contains("pub g: String"));
+    // Unknown custom type should fall back to JsValue.
+    assert!(out.contains("pub h: JsValue"));
+}
+
+#[test]
+fn generic_and_tuple_types_become_jsvalue() {
+    let src = r#"
+type Box { items: Vec<i64>, pair: (i64, String) }
+
+machine M {
+    state S
+}
+"#;
+    let out = gen(src);
+    // Both Generic and Tuple map to JsValue per codegen policy.
+    assert!(out.contains("pub items: JsValue"));
+    assert!(out.contains("pub pair: JsValue"));
+}
+
+#[test]
+fn sync_transition_emits_result_jsvalue() {
+    let src = r#"
+machine Door {
+    state Closed
+    state Open
+    transition open: Closed -> Open
+    on open() { goto Open(); }
+}
+"#;
+    let out = gen(src);
+    assert!(out.contains("pub fn open(&mut self) -> Result<(), JsValue>"));
+    assert!(out.contains("return Err(JsValue::from_str(\"invalid transition\"))"));
+    assert!(out.contains("self.state = DoorState::Open"));
+}
+
+#[test]
+fn timeout_transition_emits_promise_async_branch() {
+    let src = r#"
+machine Net {
+    state Idle
+    state Active
+    transition connect: Idle -> Active timeout 5s
+    on connect() { goto Active(); }
+}
+"#;
+    let out = gen(src);
+    assert!(out.contains("connectAsync"));
+    assert!(out.contains("pub fn connect_async(&mut self) -> Promise"));
+    assert!(out.contains("Promise::reject"));
+    assert!(out.contains("future_to_promise"));
+}
+
+#[test]
+fn generic_machine_emits_generic_bounds() {
+    let src = r#"
+machine Box<T> {
+    state Empty
+    state Full
+    transition fill: Empty -> Full
+    on fill() { goto Full(); }
+}
+"#;
+    let out = gen(src);
+    assert!(out.contains("T: Into<JsValue> + Clone"));
+    assert!(out.contains("pub struct Box<T"));
+    assert!(out.contains("pub enum BoxState<T"));
+}
+
+#[test]
+fn constructor_uses_first_state() {
+    let src = r#"
+machine Light {
+    state Off
+    state On
+}
+"#;
+    let out = gen(src);
+    assert!(out.contains("#[wasm_bindgen(constructor)]"));
+    assert!(out.contains("Self { state: LightState::Off }"));
+}
+
+#[test]
+fn state_method_returns_u32_discriminant() {
+    let src = r#"
+machine X { state A }
+"#;
+    let out = gen(src);
+    assert!(out.contains("pub fn state(&self) -> u32"));
+    assert!(out.contains("self.state as u32"));
+}
+
+#[test]
+fn default_impl_equivalent_to_new() {
+    let a = WasmCodegen::default();
+    let b = WasmCodegen::new();
+    let src = "machine M { state S }";
+    let program = parse_program_with_errors(src, "t.gu").expect("parses");
+    // Both should produce byte-identical output.
+    assert_eq!(a.generate(&program), b.generate(&program));
+}
+
+#[test]
+fn empty_program_still_emits_prelude_and_adapter_trait() {
+    let out = gen("");
+    assert!(out.contains("use wasm_bindgen::prelude::*;"));
+    assert!(out.contains("pub trait GustWasmEffectAdapter"));
+    assert!(out.contains("call_effect"));
+}

--- a/gust-lang/tests/wasm_codegen_coverage.rs
+++ b/gust-lang/tests/wasm_codegen_coverage.rs
@@ -155,7 +155,11 @@ machine X { state A }
 
 #[test]
 fn default_impl_equivalent_to_new() {
-    let a = WasmCodegen::default();
+    // Route through the Default trait explicitly. We can't write
+    // `WasmCodegen::default()` directly because clippy 1.95's
+    // `default_constructed_unit_structs` lint rejects it for unit
+    // structs even when a Default impl exists.
+    let a: WasmCodegen = Default::default();
     let b = WasmCodegen::new();
     let src = "machine M { state S }";
     let program = parse_program_with_errors(src, "t.gu").expect("parses");


### PR DESCRIPTION
## Summary
Adds two new test files with 26 tests total covering branches previously uncovered by the happy-path tests in `target_backends.rs`.

**Coverage deltas** (measured via cargo-llvm-cov on this branch):
| File | Before | After |
|---|---|---|
| `codegen_wasm.rs` | 64.38% | 98.75% |
| `codegen_nostd.rs` | 75.14% | 96.13% |
| Workspace total | 82.29% | 83.43% |

### `wasm_codegen_coverage.rs` (11 tests)
- Struct and enum type decls
- All primitive type mappings + unknown → `JsValue` fallback
- Generic and tuple types → `JsValue`
- Sync vs timeout transition variants (`Result` vs `Promise` paths)
- Generic machines with `T: Into<JsValue> + Clone` bounds
- Constructor / `state()` helpers
- `Default` impl parity, empty-program prelude

### `nostd_codegen_coverage.rs` (15 tests)
- Empty vs field-bearing first-state constructors
- Field-bearing vs empty from-state patterns (`{ .. }` vs bare)
- Every `nostd_type` arm: `Vec → HVec`, `Option`, `Result` (both arms), unknown generic passthrough, `Tuple`, all primitives, unknown `Simple`
- Generic machines with `T: Clone` bound
- `Default` impl parity, prelude emission, error arm

## Why
v0.2.0 tightening pass. WASM and no_std codegen are advertised target backends; users deserve parity with the Rust/Go backends that sit above 90% line coverage.

## Test plan
- [x] `cargo test -p gust-lang --test wasm_codegen_coverage` — 11 tests pass
- [x] `cargo test -p gust-lang --test nostd_codegen_coverage` — 15 tests pass
- [x] `cargo fmt --all -- --check` — clean
- [ ] CI workspace tests green

---
Generated with [Claude Code](https://claude.ai/code)