### PR TITLE
feat(ast,validator): expression-level source spans (closes #46)

### DIFF
--- a/gust-lang/src/ast.rs
+++ b/gust-lang/src/ast.rs
@@ -190,6 +190,7 @@ pub enum Statement {
         condition: Expr,
         then_block: Block,
         else_block: Option<Block>,
+        span: Span,
     },
     Goto {
         state: String,
@@ -244,7 +245,7 @@ pub enum Expr {
     Ident(String),
     FieldAccess(Box<Expr>, String),
     FnCall(String, Vec<Expr>),
-    BinOp(Box<Expr>, BinOp, Box<Expr>),
+    BinOp(Box<Expr>, BinOp, Box<Expr>, Span),
     UnaryOp(UnaryOp, Box<Expr>),
     Perform(String, Vec<Expr>), // effect name, arguments
     Path(String, String),       // Enum::Variant qualified path

--- a/gust-lang/src/codegen.rs
+++ b/gust-lang/src/codegen.rs
@@ -712,6 +712,7 @@ pub enum {name}Error {{
                 condition,
                 then_block,
                 else_block,
+                span: _,
             } => {
                 let cond = self.expr_to_rust(condition, &async_effects);
                 let cond = if cond.starts_with('(') && cond.ends_with(')') {
@@ -872,7 +873,7 @@ pub enum {name}Error {{
                     .collect();
                 format!("{}({})", name, arg_strs.join(", "))
             }
-            Expr::BinOp(left, op, right) => {
+            Expr::BinOp(left, op, right, _) => {
                 format!(
                     "({} {} {})",
                     self.expr_to_rust(left, async_effects),

--- a/gust-lang/src/codegen_common.rs
+++ b/gust-lang/src/codegen_common.rs
@@ -21,6 +21,7 @@ pub fn handler_uses_perform(block: &Block) -> bool {
             condition,
             then_block,
             else_block,
+            span: _,
         } => {
             expr_has_perform(condition)
                 || handler_uses_perform(then_block)
@@ -206,6 +207,7 @@ fn collect_idents_stmt(stmt: &Statement, ctx_param: Option<&str>, set: &mut Hash
             condition,
             then_block,
             else_block,
+            span: _,
         } => {
             collect_idents_expr(condition, ctx_param, set);
             for s in &then_block.statements {
@@ -247,7 +249,7 @@ fn collect_idents_expr(expr: &Expr, ctx_param: Option<&str>, set: &mut HashSet<S
                 collect_idents_expr(a, ctx_param, set);
             }
         }
-        Expr::BinOp(l, _, r) => {
+        Expr::BinOp(l, _, r, _) => {
             collect_idents_expr(l, ctx_param, set);
             collect_idents_expr(r, ctx_param, set);
         }
@@ -313,6 +315,7 @@ fn stmt_references_ctx(stmt: &Statement) -> bool {
             condition,
             then_block,
             else_block,
+            span: _,
         } => {
             expr_references_ctx(condition)
                 || handler_body_references_ctx(then_block)
@@ -332,7 +335,7 @@ pub fn expr_references_ctx(expr: &Expr) -> bool {
         Expr::Ident(name) => name == "ctx",
         Expr::FieldAccess(base, _) => expr_references_ctx(base),
         Expr::FnCall(_, args) | Expr::Perform(_, args) => args.iter().any(expr_references_ctx),
-        Expr::BinOp(l, _, r) => expr_references_ctx(l) || expr_references_ctx(r),
+        Expr::BinOp(l, _, r, _) => expr_references_ctx(l) || expr_references_ctx(r),
         Expr::UnaryOp(_, e) => expr_references_ctx(e),
         _ => false,
     }
@@ -341,7 +344,7 @@ pub fn expr_references_ctx(expr: &Expr) -> bool {
 fn expr_has_perform(expr: &Expr) -> bool {
     match expr {
         Expr::Perform(_, _) => true,
-        Expr::BinOp(l, _, r) => expr_has_perform(l) || expr_has_perform(r),
+        Expr::BinOp(l, _, r, _) => expr_has_perform(l) || expr_has_perform(r),
         Expr::UnaryOp(_, e) => expr_has_perform(e),
         Expr::FnCall(_, args) => args.iter().any(expr_has_perform),
         Expr::FieldAccess(base, _) => expr_has_perform(base),

--- a/gust-lang/src/codegen_go.rs
+++ b/gust-lang/src/codegen_go.rs
@@ -832,6 +832,7 @@ impl GoCodegen {
                 condition,
                 then_block,
                 else_block,
+                span: _,
             } => {
                 let cond = self.expr_to_go(condition);
                 // Strip outer parens for Go if-conditions
@@ -1050,7 +1051,7 @@ impl GoCodegen {
                 let arg_strs: Vec<String> = args.iter().map(|a| self.expr_to_go(a)).collect();
                 format!("{}({})", name, arg_strs.join(", "))
             }
-            Expr::BinOp(left, op, right) => {
+            Expr::BinOp(left, op, right, _) => {
                 let l = self.expr_to_go(left);
                 let r = self.expr_to_go(right);
                 let op_str = match op {

--- a/gust-lang/src/format.rs
+++ b/gust-lang/src/format.rs
@@ -186,6 +186,7 @@ fn format_statement(stmt: &Statement, indent: usize) -> String {
             condition,
             then_block,
             else_block,
+            span: _,
         } => {
             let mut out = format!("{pad}if {} {{\n", format_expr(condition));
             out.push_str(&format_block(then_block, indent + 1));
@@ -225,7 +226,7 @@ fn format_expr(expr: &Expr) -> String {
             let arg_strs: Vec<String> = args.iter().map(format_expr).collect();
             format!("{name}({})", arg_strs.join(", "))
         }
-        Expr::BinOp(left, op, right) => {
+        Expr::BinOp(left, op, right, _) => {
             format!(
                 "{} {} {}",
                 format_expr(left),

--- a/gust-lang/src/parser.rs
+++ b/gust-lang/src/parser.rs
@@ -666,6 +666,7 @@ fn parse_pattern(pair: Pair<Rule>) -> Pattern {
 }
 
 fn parse_if_stmt(pair: Pair<Rule>) -> Statement {
+    let span = span_from_pair(&pair);
     let mut inner = pair.into_inner();
     let condition = parse_expr(inner.next().unwrap());
     let then_block = parse_block(inner.next().unwrap());
@@ -680,6 +681,7 @@ fn parse_if_stmt(pair: Pair<Rule>) -> Statement {
         condition,
         then_block,
         else_block,
+        span,
     }
 }
 
@@ -688,26 +690,29 @@ fn parse_expr(pair: Pair<Rule>) -> Expr {
 }
 
 fn parse_or_expr(pair: Pair<Rule>) -> Expr {
+    let span = span_from_pair(&pair);
     let mut inner = pair.into_inner();
     let mut left = parse_and_expr(inner.next().unwrap());
     for right_pair in inner {
         let right = parse_and_expr(right_pair);
-        left = Expr::BinOp(Box::new(left), BinOp::Or, Box::new(right));
+        left = Expr::BinOp(Box::new(left), BinOp::Or, Box::new(right), span);
     }
     left
 }
 
 fn parse_and_expr(pair: Pair<Rule>) -> Expr {
+    let span = span_from_pair(&pair);
     let mut inner = pair.into_inner();
     let mut left = parse_cmp_expr(inner.next().unwrap());
     for right_pair in inner {
         let right = parse_cmp_expr(right_pair);
-        left = Expr::BinOp(Box::new(left), BinOp::And, Box::new(right));
+        left = Expr::BinOp(Box::new(left), BinOp::And, Box::new(right), span);
     }
     left
 }
 
 fn parse_cmp_expr(pair: Pair<Rule>) -> Expr {
+    let span = span_from_pair(&pair);
     let mut inner = pair.into_inner();
     let left = parse_add_expr(inner.next().unwrap());
     if let Some(op_pair) = inner.next() {
@@ -721,13 +726,14 @@ fn parse_cmp_expr(pair: Pair<Rule>) -> Expr {
             _ => unreachable!(),
         };
         let right = parse_add_expr(inner.next().unwrap());
-        Expr::BinOp(Box::new(left), op, Box::new(right))
+        Expr::BinOp(Box::new(left), op, Box::new(right), span)
     } else {
         left
     }
 }
 
 fn parse_add_expr(pair: Pair<Rule>) -> Expr {
+    let span = span_from_pair(&pair);
     let mut inner = pair.into_inner();
     let mut left = parse_mul_expr(inner.next().unwrap());
     while let Some(op_pair) = inner.next() {
@@ -737,12 +743,13 @@ fn parse_add_expr(pair: Pair<Rule>) -> Expr {
             _ => unreachable!(),
         };
         let right = parse_mul_expr(inner.next().unwrap());
-        left = Expr::BinOp(Box::new(left), op, Box::new(right));
+        left = Expr::BinOp(Box::new(left), op, Box::new(right), span);
     }
     left
 }
 
 fn parse_mul_expr(pair: Pair<Rule>) -> Expr {
+    let span = span_from_pair(&pair);
     let mut inner = pair.into_inner();
     let mut left = parse_unary_expr(inner.next().unwrap());
     while let Some(op_pair) = inner.next() {
@@ -753,7 +760,7 @@ fn parse_mul_expr(pair: Pair<Rule>) -> Expr {
             _ => unreachable!(),
         };
         let right = parse_unary_expr(inner.next().unwrap());
-        left = Expr::BinOp(Box::new(left), op, Box::new(right));
+        left = Expr::BinOp(Box::new(left), op, Box::new(right), span);
     }
     left
 }

--- a/gust-lang/src/validator.rs
+++ b/gust-lang/src/validator.rs
@@ -711,7 +711,7 @@ fn check_expr_perform_arity(
             // Expr::Perform has no span; fall back to default span at call site.
             check_perform_args(effect, args, Span::default(), effects, file, report);
         }
-        Expr::BinOp(left, _, right) => {
+        Expr::BinOp(left, _, right, _) => {
             check_expr_perform_arity(left, effects, file, report);
             check_expr_perform_arity(right, effects, file, report);
         }
@@ -834,6 +834,7 @@ fn collect_effects_from_block(
                 condition,
                 then_block,
                 else_block,
+                span: _,
             } => {
                 collect_effects_from_expr(condition, declared, used_declared, unknown);
                 collect_effects_from_block(then_block, declared, used_declared, unknown);
@@ -1005,6 +1006,7 @@ fn collect_ctx_fields_from_stmt(stmt: &Statement, out: &mut Vec<String>) {
             condition,
             then_block,
             else_block,
+            span: _,
         } => {
             collect_ctx_fields_from_expr(condition, out);
             collect_ctx_fields_from_block(then_block, out);
@@ -1035,7 +1037,7 @@ fn collect_ctx_fields_from_expr(expr: &Expr, out: &mut Vec<String>) {
             // For nested access like ctx.config.name, recurse to find the ctx.config part
             collect_ctx_fields_from_expr(base, out);
         }
-        Expr::BinOp(l, _, r) => {
+        Expr::BinOp(l, _, r, _) => {
             collect_ctx_fields_from_expr(l, out);
             collect_ctx_fields_from_expr(r, out);
         }
@@ -1070,7 +1072,7 @@ fn collect_effects_from_expr(
                 collect_effects_from_expr(arg, declared, used_declared, unknown);
             }
         }
-        Expr::BinOp(left, _, right) => {
+        Expr::BinOp(left, _, right, _) => {
             collect_effects_from_expr(left, declared, used_declared, unknown);
             collect_effects_from_expr(right, declared, used_declared, unknown);
         }
@@ -1184,7 +1186,7 @@ fn infer_expr_type(expr: &Expr, ctx: &TypeContext<'_>) -> Option<TypeExpr> {
             .get(effect_name.as_str())
             .map(|e| e.return_type.clone()),
         Expr::FieldAccess(base, field) => infer_field_access_type(base, field, ctx),
-        Expr::BinOp(left, op, _right) => {
+        Expr::BinOp(left, op, _right, _) => {
             use crate::ast::BinOp::*;
             match op {
                 Eq | Neq | Lt | Lte | Gt | Gte | And | Or => {
@@ -1437,7 +1439,7 @@ fn check_binop_types_in_expr(
     report: &mut ValidationReport,
 ) {
     match expr {
-        Expr::BinOp(left, op, right) => {
+        Expr::BinOp(left, op, right, span) => {
             check_binop_types_in_expr(left, ctx, file, report);
             check_binop_types_in_expr(right, ctx, file, report);
 
@@ -1464,8 +1466,8 @@ fn check_binop_types_in_expr(
                     };
                     report.errors.push(GustError {
                         file: file.to_string(),
-                        line: 0,
-                        col: 0,
+                        line: span.start_line,
+                        col: span.start_col,
                         message: format!(
                             "binary operator '{}' has incompatible operand types: {} vs {}",
                             op_str,
@@ -1515,6 +1517,7 @@ fn check_if_branch_consistency(
             Statement::If {
                 then_block,
                 else_block,
+                span,
                 ..
             } => {
                 // Recurse first so nested if/else are checked independently.
@@ -1538,8 +1541,8 @@ fn check_if_branch_consistency(
                         };
                         report.warnings.push(GustWarning {
                             file: file.to_string(),
-                            line: 0,
-                            col: 0,
+                            line: span.start_line,
+                            col: span.start_col,
                             message: format!(
                                 "handler '{}' has inconsistent if/else: the {} branch transitions but the {} branch may fall through",
                                 handler_name, terminating_branch, fall_through_branch,

--- a/gust-lang/tests/diagnostics_validation.rs
+++ b/gust-lang/tests/diagnostics_validation.rs
@@ -1666,3 +1666,80 @@ machine Calc {
         report.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
     );
 }
+
+// === Span coverage for #46 — previously these diagnostics reported line 0, col 0. ===
+
+#[test]
+fn binop_type_mismatch_diagnostic_points_to_source_location() {
+    let source = r#"
+machine Calc {
+    state Start(a: i64, b: String)
+    state Done
+
+    transition go: Start -> Done
+
+    on go(ctx: Ctx) {
+        let r: i64 = ctx.a + ctx.b;
+        goto Done();
+    }
+}
+"#;
+    let program = parse_program_with_errors(source, "test.gu").expect("should parse");
+    let report = validate_program(&program, "test.gu", source);
+
+    let binop_err = report
+        .errors
+        .iter()
+        .find(|e| e.message.contains("binary operator") && e.message.contains("incompatible"))
+        .expect("should report binop type mismatch");
+
+    assert!(
+        binop_err.line > 0,
+        "binop diagnostic must carry a real line number (got {}), #46",
+        binop_err.line
+    );
+    assert!(
+        binop_err.col > 0,
+        "binop diagnostic must carry a real column (got {}), #46",
+        binop_err.col
+    );
+}
+
+#[test]
+fn if_branch_inconsistency_diagnostic_points_to_source_location() {
+    let source = r#"
+machine Router {
+    state Start(cond: bool)
+    state Done
+
+    transition check: Start -> Done
+
+    on check(ctx: Ctx) {
+        if ctx.cond {
+            goto Done();
+        } else {
+            let x: i64 = 1;
+        }
+    }
+}
+"#;
+    let program = parse_program_with_errors(source, "test.gu").expect("should parse");
+    let report = validate_program(&program, "test.gu", source);
+
+    let if_warn = report
+        .warnings
+        .iter()
+        .find(|w| w.message.contains("inconsistent if/else"))
+        .expect("should warn on inconsistent if/else");
+
+    assert!(
+        if_warn.line > 0,
+        "if/else diagnostic must carry a real line number (got {}), #46",
+        if_warn.line
+    );
+    assert!(
+        if_warn.col > 0,
+        "if/else diagnostic must carry a real column (got {}), #46",
+        if_warn.col
+    );
+}

--- a/gust-mcp/src/lib.rs
+++ b/gust-mcp/src/lib.rs
@@ -611,7 +611,7 @@ pub fn serialize_program(program: &gust_lang::ast::Program) -> Value {
                 "name": name,
                 "args": args.iter().map(serialize_expr).collect::<Vec<_>>()
             }),
-            Expr::BinOp(l, op, r) => json!({
+            Expr::BinOp(l, op, r, _) => json!({
                 "kind": "binop",
                 "op": serialize_binop(op),
                 "left": serialize_expr(l),
@@ -664,6 +664,7 @@ pub fn serialize_program(program: &gust_lang::ast::Program) -> Value {
                 condition,
                 then_block,
                 else_block,
+                span: _,
             } => json!({
                 "kind": "if",
                 "condition": serialize_expr(condition),


### PR DESCRIPTION
## Summary
Closes #46 by adding `Span` to `Statement::If` and `Expr::BinOp`, then wiring it into the diagnostics that previously reported `line: 0, col: 0`:
- If/else branch termination consistency warnings
- Binary operator operand compatibility errors

## Changes
- **`ast.rs`**: `Statement::If` gains `span: Span`; `Expr::BinOp` gains a trailing `Span` tuple element.
- **`parser.rs`**: `parse_if_stmt` and all five `parse_*_expr` functions capture the enclosing pair's span and thread it through. Chained BinOps within one rule share the rule's span — this points at the full expression, which is precise enough for the diagnostic and matches how the rest of the AST handles spans.
- **`validator.rs`**: `check_binop_types_in_expr` and `check_if_branch_consistency` emit diagnostics at the real line/col.
- Pattern-site updates in `codegen.rs`, `codegen_common.rs`, `codegen_go.rs`, `format.rs`, `validator.rs`, `gust-mcp/src/lib.rs` — all mechanical (`_` or `span: _`).
- Two new regression tests in `diagnostics_validation.rs` assert `line > 0` and `col > 0` on both diagnostics.

## Why
This was the only remaining open issue and the only Phase 1 validator follow-up from the `CHANGELOG` "Known limitations" list. Resolves the UX regression where users would see diagnostics pointing at `0:0` with no source context.

## Test plan
- [x] `cargo test --workspace --all-features` — all green
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] New tests `binop_type_mismatch_diagnostic_points_to_source_location` and `if_branch_inconsistency_diagnostic_points_to_source_location` pass and would fail on master
- [ ] CI green

Closes #46

---
Generated with [Claude Code](https://claude.ai/code)