### PR TITLE
fix(docs): resolve broken intra-doc link + enforce rustdoc in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,10 @@ jobs:
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
       - name: Workspace tests
         run: cargo test --workspace --all-targets --all-features
+      - name: Rustdoc (deny broken links and warnings)
+        env:
+          RUSTDOCFLAGS: "-D warnings -D rustdoc::broken_intra_doc_links"
+        run: cargo doc --workspace --no-deps --all-features
 
   examples-and-go:
     runs-on: ubuntu-latest

--- a/gust-lang/src/codegen.rs
+++ b/gust-lang/src/codegen.rs
@@ -17,7 +17,7 @@ use crate::codegen_common::{
 use std::collections::HashSet;
 
 /// Rust code generator. Consumes a validated [`Program`] and emits
-/// idiomatic `.g.rs` source targeting [`gust_runtime`].
+/// idiomatic `.g.rs` source targeting the `gust_runtime` crate.
 pub struct RustCodegen {
     output: String,
     indent: usize,


### PR DESCRIPTION
## Summary
Fixes a broken rustdoc intra-doc link introduced by PR #57 and adds a CI guard so the class of bug can't recur.

## The bug (codex review, P2)
`gust-lang/src/codegen.rs:19-20` references `[\`gust_runtime\`]` as an intra-doc link, but `gust-lang` does not depend on `gust-runtime` (the compiler generates code that uses it; the compiler itself does not import it). Rustdoc fails the build under the common setting `RUSTDOCFLAGS='-D rustdoc::broken_intra_doc_links'`:

\`\`\`
error: unresolved link to \`gust_runtime\`
  --> gust-lang/src/codegen.rs:20:42
\`\`\`

## Fix
Plain backtick code span — "targeting the \`gust_runtime\` crate" — which does not trigger intra-doc resolution. No API or behavior change.

## CI hardening
New step in the \`core\` job:
\`\`\`yaml
- name: Rustdoc (deny broken links and warnings)
  env:
    RUSTDOCFLAGS: \"-D warnings -D rustdoc::broken_intra_doc_links\"
  run: cargo doc --workspace --no-deps --all-features
\`\`\`
Any future broken rustdoc link or warning now fails CI.

## Test plan
- [x] \`RUSTDOCFLAGS='-D warnings -D rustdoc::broken_intra_doc_links' cargo doc --workspace --no-deps --all-features\` — clean
- [x] Full \`cargo test --workspace --all-features\` still green
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\` still clean
- [ ] CI green on the new rustdoc step

---
Generated with [Claude Code](https://claude.ai/code)