### PR TITLE
refactor(parser,mcp,codegen_go): tighten public surface + fix panic points

### DIFF
--- a/gust-lang/src/codegen_go.rs
+++ b/gust-lang/src/codegen_go.rs
@@ -1114,7 +1114,10 @@ impl GoCodegen {
                     variant.clone()
                 }
             }
-            Pattern::Wildcard => unreachable!("wildcard patterns are handled by switch default"),
+            // Go blank identifier — handles any wildcard that reaches here directly
+            // rather than panicking if a future language feature routes a wildcard
+            // through pattern_to_go.
+            Pattern::Wildcard => "_".to_string(),
         }
     }
 

--- a/gust-lang/src/lib.rs
+++ b/gust-lang/src/lib.rs
@@ -46,7 +46,7 @@ pub mod error;
 /// Comment-preserving Gust source formatter.
 pub mod format;
 /// pest-based parser converting source text into [`ast::Program`].
-pub mod parser;
+pub(crate) mod parser;
 /// Semantic validation producing a [`ValidationReport`] with rich
 /// diagnostics (undefined references, type mismatches, handler-safety
 /// warnings for `action` declarations, etc.).

--- a/gust-mcp/src/lib.rs
+++ b/gust-mcp/src/lib.rs
@@ -334,7 +334,8 @@ pub fn tool_check(args: &Value) -> Result<String, String> {
                 }],
                 "warnings": []
             });
-            return Ok(serde_json::to_string_pretty(&result).unwrap());
+            return serde_json::to_string_pretty(&result)
+                .map_err(|e| format!("serialization failure: {e}"));
         }
     };
 
@@ -368,7 +369,7 @@ pub fn tool_check(args: &Value) -> Result<String, String> {
         .collect();
 
     let result = json!({ "errors": errors, "warnings": warnings });
-    Ok(serde_json::to_string_pretty(&result).unwrap())
+    serde_json::to_string_pretty(&result).map_err(|e| format!("serialization failure: {e}"))
 }
 
 // ---------------------------------------------------------------------------
@@ -500,7 +501,7 @@ pub fn tool_parse(args: &Value) -> Result<String, String> {
         .map_err(|e| format!("Parse error at {}:{}: {}", e.line, e.col, e.message))?;
 
     let ast = serialize_program(&program);
-    Ok(serde_json::to_string_pretty(&ast).unwrap())
+    serde_json::to_string_pretty(&ast).map_err(|e| format!("serialization failure: {e}"))
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Fix 1 — `parser` module demoted to `pub(crate)`**: `GustParser` and `Rule` are pest implementation details. Exposing them makes any grammar refactor a semver-breaking change. `parse_program` / `parse_program_with_errors` remain re-exported from the crate root, so no callers are affected.
- **Fix 2 — Replace `.unwrap()` on `serde_json::to_string_pretty` in gust-mcp (3 sites)**: Each handler already returns `Result<String, String>`; the three `.unwrap()` calls were the only remaining panic paths in hot MCP request handlers. Converted to `.map_err(|e| format!("serialization failure: {e}"))`.
- **Fix 3 — Replace `unreachable!` in `pattern_to_go` (codegen_go.rs:1117)**: Go's blank identifier `_` is the correct encoding for a wildcard pattern. Panicking here if a future language feature routes a wildcard through `pattern_to_go` directly was a latent crash; returning `"_"` keeps the generated code correct.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo test --workspace --all-features` — all tests pass (0 failures)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `RUSTDOCFLAGS="-D warnings -D rustdoc::broken_intra_doc_links" cargo doc --workspace --no-deps --all-features` — clean
- [x] No direct `gust_lang::parser::` imports exist anywhere in the workspace (confirmed via grep before demoting)

---
Generated with [Claude Code](https://claude.ai/code)