### PR TITLE
fix(codegen): strip `use std::*` imports to prevent target-language collisions

### DIFF
--- a/gust-lang/src/codegen.rs
+++ b/gust-lang/src/codegen.rs
@@ -94,6 +94,14 @@ impl RustCodegen {
             if use_path.segments.is_empty() {
                 continue;
             }
+            // `std::*` is a Gust-virtual namespace for stdlib machines/types
+            // (see `gust-stdlib`). The consumer's build pipeline is
+            // responsible for compiling the stdlib source and placing it in
+            // the same module as the dependent machine, so no Rust `use`
+            // statement is emitted. See issue #66.
+            if use_path.segments.first().map(String::as_str) == Some("std") {
+                continue;
+            }
             self.line(&format!("use {};", use_path.segments.join("::")));
         }
         self.newline();

--- a/gust-lang/src/codegen_go.rs
+++ b/gust-lang/src/codegen_go.rs
@@ -93,6 +93,13 @@ impl GoCodegen {
             if use_path.segments.is_empty() {
                 continue;
             }
+            // `std::*` is a Gust-virtual namespace for stdlib machines/types.
+            // The consumer's build pipeline is responsible for compiling
+            // stdlib sources into the same Go package, so no import is
+            // emitted. See issue #66.
+            if use_path.segments.first().map(String::as_str) == Some("std") {
+                continue;
+            }
             imports.push(map_use_path_to_go_import(&use_path.segments));
         }
         if program

--- a/gust-lang/tests/import_resolution.rs
+++ b/gust-lang/tests/import_resolution.rs
@@ -54,3 +54,94 @@ machine Processor {
     assert!(output.contains("\"encoding/json\""));
     assert!(output.contains("\"fmt\""));
 }
+
+// === Regression for issue #66 ==============================================
+// `use std::*` is a Gust-virtual namespace for stdlib machines/types. Neither
+// Rust nor Go codegen may emit it literally, because Rust's `std` crate has
+// no matching item and `std/Foo` is not a valid Go module path. Stdlib
+// sources are compiled separately by the consumer's build pipeline.
+
+#[test]
+fn std_imports_stripped_from_rust_codegen() {
+    let source = r#"
+use std::EngineFailure;
+
+machine Worker {
+    state Idle
+    state Done
+
+    transition finish: Idle -> Done
+
+    on finish() {
+        goto Done();
+    }
+}
+"#;
+
+    let program = parse_program(source).expect("source should parse");
+    let output = RustCodegen::new().generate(&program);
+
+    assert!(
+        !output.contains("use std::EngineFailure"),
+        "std::* imports must not leak into generated Rust (collides with std crate). \
+         Generated output:\n{output}"
+    );
+    // Sanity: the rest of the prelude is still there.
+    assert!(output.contains("use gust_runtime::prelude::*;"));
+}
+
+#[test]
+fn std_imports_stripped_from_go_codegen() {
+    let source = r#"
+use std::EngineFailure;
+
+machine Worker {
+    state Idle
+    state Done
+
+    transition finish: Idle -> Done
+
+    on finish() {
+        goto Done();
+    }
+}
+"#;
+
+    let program = parse_program(source).expect("source should parse");
+    let output = GoCodegen::new().generate(&program, "testpkg");
+
+    assert!(
+        !output.contains("\"std/EngineFailure\""),
+        "std::* imports must not leak into Go import list. Generated output:\n{output}"
+    );
+    assert!(
+        !output.contains("\"std\""),
+        "Gust's `std` namespace must not map to a Go `std` import. Generated output:\n{output}"
+    );
+}
+
+#[test]
+fn non_std_imports_still_emitted_after_std_filter() {
+    // Mixing `std::*` with a real import: the real import must survive.
+    let source = r#"
+use std::EngineFailure;
+use crate::domain::OrderId;
+
+machine Worker {
+    state Idle
+    state Done
+
+    transition finish: Idle -> Done
+
+    on finish() {
+        goto Done();
+    }
+}
+"#;
+
+    let program = parse_program(source).expect("source should parse");
+    let rust_output = RustCodegen::new().generate(&program);
+
+    assert!(!rust_output.contains("use std::EngineFailure"));
+    assert!(rust_output.contains("use crate::domain::OrderId;"));
+}


### PR DESCRIPTION
## Summary
Closes #66. Filters `use std::*` paths out of both Rust and Go codegen `emit_prelude`, because `std::*` in Gust is a virtual namespace for stdlib machines/types — emitting it literally collides with Rust's own `std` crate and produces an invalid Go import path.

## Discovery
PR #65 (workflow_engine example rewrite for Corsac) hit this immediately: `use std::EngineFailure;` is the canonical import for the EngineFailure stdlib type, but the generated `workflow.g.rs` wouldn't compile. The workaround there was a brittle `build.rs` hack (copy engine_failure.gu, compile separately, strip the broken line).

## Treatment
The consumer's build pipeline is responsible for compiling stdlib sources alongside the dependent machine (placing them in the same module/package), so no target-language `use`/`import` needs to be emitted. Both codegens now skip `use_paths` whose first segment is `"std"`.

## Tests
- `std_imports_stripped_from_rust_codegen` — bare `use std::EngineFailure;` produces no `use std::...` line in Rust output.
- `std_imports_stripped_from_go_codegen` — no `"std/EngineFailure"` or `"std"` in Go import list.
- `non_std_imports_still_emitted_after_std_filter` — mixed `use std::...` + `use crate::...` confirms the filter is scoped; real imports survive.

## Impact on Corsac
Without this fix, the documented onboarding path (use `EngineFailure` via `use std::EngineFailure;`, see the workflow-runtime guide in PR #62) doesn't actually work. This unblocks it.

## Follow-up
PR #65's `build.rs` stripping hack can be deleted once this lands. Small cleanup PR after merge.

## Test plan
- [x] `cargo test --workspace --all-features` — 42 test suites green
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `RUSTDOCFLAGS='-D warnings -D rustdoc::broken_intra_doc_links' cargo doc --workspace --no-deps --all-features` — clean
- [ ] CI green

Closes #66

---
Generated with [Claude Code](https://claude.ai/code)