### PR TITLE
feat(codegen): annotate generated effect methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ The [Gust VS Code extension](editors/vscode/) provides:
 - Format on save
 - Custom file icon
 
-`v0.1.0` intentionally does not advertise rename or find-references in the LSP because symbol resolution is not yet scope-aware enough to do those edits safely.
+The LSP intentionally does not advertise rename or find-references yet because
+the supported symbol operations are still current-file scoped.
 
 ## Language Keywords
 
@@ -135,6 +136,7 @@ The [Gust VS Code extension](editors/vscode/) provides:
 | `state`      | Declare a state with optional typed fields           |
 | `transition` | Declare a valid state transition (`from -> targets`) |
 | `effect`     | Declare a tracked side effect with signature         |
+| `action`     | Declare a non-idempotent externally visible operation |
 | `on`         | Handle a transition with logic                       |
 | `goto`       | Transition to a new state with field values          |
 | `perform`    | Execute a tracked effect (usable as expression)      |
@@ -148,7 +150,7 @@ The [Gust VS Code extension](editors/vscode/) provides:
 
 ## Release Status
 
-**v0.1.0** — initial public release.
+**v0.2.0** — current public release.
 
 - [x] PEG grammar, parser, AST
 - [x] Rust and Go code generation
@@ -156,6 +158,9 @@ The [Gust VS Code extension](editors/vscode/) provides:
 - [x] `gust-build` Cargo integration
 - [x] Diagnostics and validation with suggestions
 - [x] Async handlers/effects, enums, tuples, `match`
+- [x] `action` keyword and handler-safety diagnostics for replay-aware runtimes
+- [x] `EngineFailure` in `gust-stdlib`
+- [x] JSON Schema code generation and `gust doctor`
 - [x] Channels, supervision, lifecycle timeouts
 - [x] Additional targets (`wasm`, `nostd`, `ffi`)
 - [x] LSP with hover, diagnostics, go-to-definition, formatting
@@ -170,7 +175,7 @@ See [ROADMAP.md](ROADMAP.md) for what's next.
 
 - Inter-machine communication is currently local in-process channels only. Network transport is intentionally deferred.
 - Cross-file `use` declarations resolve types but cross-file go-to-definition in the LSP is not yet implemented.
-- LSP rename and find-references are disabled in `v0.1.0` until symbol resolution becomes scope-aware enough to avoid unsafe textual edits.
+- LSP rename and find-references are not advertised until symbol resolution becomes scope-aware enough to avoid unsafe textual edits.
 - Context field (`ctx.field`) error locations point to the handler declaration rather than the exact field access expression.
 
 ## Contributing

--- a/docs/src/advanced/compiler_plugins.md
+++ b/docs/src/advanced/compiler_plugins.md
@@ -1,6 +1,6 @@
 # Compiler Plugins
 
-This page is part of the v0.1.0 documentation set for Gust.
+This page is part of the Gust documentation set.
 
 ```gust
 machine DocsExample {

--- a/docs/src/appendix/changelog.md
+++ b/docs/src/appendix/changelog.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## v0.2.0
+
+Current public release of Gust with workflow-runtime semantics, stronger
+diagnostics, schema output, and broader test coverage.
+
+### Highlights
+
+- `action` keyword for non-idempotent, externally visible operations
+- Handler-safety warnings for replay-aware runtimes
+- `EngineFailure` in `gust-stdlib`
+- Goto field type validation and effect return type checking
+- Effect argument arity validation and match exhaustiveness diagnostics
+- JSON Schema code generation via `--target schema` / `gust schema`
+- `gust doctor` environment diagnostics
+- Optional tracing instrumentation in Rust code generation
+
+### Hardening Included in v0.2.0
+
+- Public API rustdoc is enforced crate-wide
+- Parser infallible paths use explicit `GRAMMAR_INVARIANT` expectations
+- Expression-level source spans improve validator diagnostic locations
+- CLI, LSP, MCP, runtime, stdlib, and codegen test coverage expanded
+- Broken rustdoc intra-doc links fail CI
+
 ## v0.1.0
 
 Initial public release of Gust with end-to-end language, tooling, and runtime support.

--- a/docs/src/appendix/faq.md
+++ b/docs/src/appendix/faq.md
@@ -2,12 +2,14 @@
 
 ## Is Gust production-ready?
 
-`v0.1.0` is intended as an initial stable release for core workflows:
+`v0.2.0` is intended as a stable release for core state-machine workflows:
 
 - parse and validate `.gu` files
 - generate Rust and Go code
 - use CLI tooling (`build`, `watch`, `check`, `fmt`, `diagram`, `init`)
 - use runtime/channel/supervision features shipped in this repository
+- model replay-sensitive workflow operations with `effect` and `action`
+- export JSON Schema for machine contracts
 
 ## Is Gust a replacement for Rust or Go?
 
@@ -28,7 +30,7 @@ See [Known Limitations](known_limitations.md) for details.
 
 ## Does Gust support networked machine-to-machine transport?
 
-Not in `v0.1.0`. Inter-machine communication currently targets local in-process channels.
+Not yet. Inter-machine communication currently targets local in-process channels.
 
 ## Which targets are supported?
 

--- a/docs/src/appendix/grammar.md
+++ b/docs/src/appendix/grammar.md
@@ -1,6 +1,6 @@
 # Grammar
 
-This page is part of the v0.1.0 documentation set for Gust.
+This page is part of the Gust documentation set.
 
 ```gust
 machine DocsExample {

--- a/docs/src/appendix/known_limitations.md
+++ b/docs/src/appendix/known_limitations.md
@@ -1,6 +1,6 @@
 # Known Limitations
 
-This page tracks current, intentional limitations in `v0.1.0`.
+This page tracks current, intentional limitations in Gust.
 
 ## Nested Cargo Workspaces and `gust init`
 
@@ -15,11 +15,12 @@ If you scaffolded a project before this behavior existed and it fails due to wor
 
 ## Inter-machine Transport Scope
 
-Inter-machine communication currently uses local in-process channels. Cross-process/network transport is not part of `v0.1.0`.
+Inter-machine communication currently uses local in-process channels.
+Cross-process/network transport is intentionally deferred.
 
 ## LSP Symbol Editing
 
-Rename and find-references are intentionally disabled in `v0.1.0`.
+Rename and find-references are not advertised by the LSP.
 
 The current symbol model is not yet scope-aware enough to guarantee safe edits across identifiers, comments, and string literals. Those features will come back once the LSP can resolve symbols structurally instead of relying on textual matches.
 

--- a/docs/src/appendix/stdlib_api.md
+++ b/docs/src/appendix/stdlib_api.md
@@ -1,6 +1,6 @@
 # Stdlib API
 
-This page is part of the v0.1.0 documentation set for Gust.
+This page is part of the Gust documentation set.
 
 ```gust
 machine DocsExample {

--- a/docs/src/cookbook/circuit_breaker.md
+++ b/docs/src/cookbook/circuit_breaker.md
@@ -1,6 +1,6 @@
 # Circuit Breaker
 
-This page is part of the v0.1.0 documentation set for Gust.
+This page is part of the Gust documentation set.
 
 ```gust
 machine DocsExample {

--- a/docs/src/cookbook/cqrs.md
+++ b/docs/src/cookbook/cqrs.md
@@ -1,6 +1,6 @@
 # CQRS
 
-This page is part of the v0.1.0 documentation set for Gust.
+This page is part of the Gust documentation set.
 
 ```gust
 machine DocsExample {

--- a/docs/src/cookbook/event_sourcing.md
+++ b/docs/src/cookbook/event_sourcing.md
@@ -1,6 +1,6 @@
 # Event Sourcing
 
-This page is part of the v0.1.0 documentation set for Gust.
+This page is part of the Gust documentation set.
 
 ```gust
 machine DocsExample {

--- a/docs/src/cookbook/health_check.md
+++ b/docs/src/cookbook/health_check.md
@@ -1,6 +1,6 @@
 # Health Check
 
-This page is part of the v0.1.0 documentation set for Gust.
+This page is part of the Gust documentation set.
 
 ```gust
 machine DocsExample {

--- a/docs/src/cookbook/patterns.md
+++ b/docs/src/cookbook/patterns.md
@@ -1,6 +1,6 @@
 # Cookbook Patterns
 
-This page is part of the v0.1.0 documentation set for Gust.
+This page is part of the Gust documentation set.
 
 ```gust
 machine DocsExample {

--- a/docs/src/cookbook/pipeline.md
+++ b/docs/src/cookbook/pipeline.md
@@ -1,6 +1,6 @@
 # Pipeline
 
-This page is part of the v0.1.0 documentation set for Gust.
+This page is part of the Gust documentation set.
 
 ```gust
 machine DocsExample {

--- a/docs/src/cookbook/rate_limiting.md
+++ b/docs/src/cookbook/rate_limiting.md
@@ -1,6 +1,6 @@
 # Rate Limiting
 
-This page is part of the v0.1.0 documentation set for Gust.
+This page is part of the Gust documentation set.
 
 ```gust
 machine DocsExample {

--- a/docs/src/cookbook/request_response.md
+++ b/docs/src/cookbook/request_response.md
@@ -1,6 +1,6 @@
 # Request Response
 
-This page is part of the v0.1.0 documentation set for Gust.
+This page is part of the Gust documentation set.
 
 ```gust
 machine DocsExample {

--- a/docs/src/cookbook/worker_pool.md
+++ b/docs/src/cookbook/worker_pool.md
@@ -1,6 +1,6 @@
 # Worker Pool
 
-This page is part of the v0.1.0 documentation set for Gust.
+This page is part of the Gust documentation set.
 
 ```gust
 machine DocsExample {

--- a/docs/src/guides/debugging.md
+++ b/docs/src/guides/debugging.md
@@ -1,6 +1,6 @@
 # Debugging
 
-This page is part of the v0.1.0 documentation set for Gust.
+This page is part of the Gust documentation set.
 
 ```gust
 machine DocsExample {

--- a/docs/src/guides/migration_rust.md
+++ b/docs/src/guides/migration_rust.md
@@ -1,6 +1,6 @@
 # Migration from Rust
 
-This page is part of the v0.1.0 documentation set for Gust.
+This page is part of the Gust documentation set.
 
 ```gust
 machine DocsExample {

--- a/docs/src/guides/performance.md
+++ b/docs/src/guides/performance.md
@@ -1,6 +1,6 @@
 # Performance
 
-This page is part of the v0.1.0 documentation set for Gust.
+This page is part of the Gust documentation set.
 
 ```gust
 machine DocsExample {

--- a/docs/src/guides/security.md
+++ b/docs/src/guides/security.md
@@ -1,6 +1,6 @@
 # Security
 
-This page is part of the v0.1.0 documentation set for Gust.
+This page is part of the Gust documentation set.
 
 ```gust
 machine DocsExample {

--- a/docs/src/guides/tokio_integration.md
+++ b/docs/src/guides/tokio_integration.md
@@ -1,6 +1,6 @@
 # Tokio Integration
 
-This page is part of the v0.1.0 documentation set for Gust.
+This page is part of the Gust documentation set.
 
 ```gust
 machine DocsExample {

--- a/docs/src/guides/workflow_runtime.md
+++ b/docs/src/guides/workflow_runtime.md
@@ -574,22 +574,22 @@ type OrderProcessorDoneData struct {
 }
 ```
 
-**Effects interface** — one method per declared `effect` or `action`. Actions get
-a marker comment so downstream tooling can identify them without re-parsing the
-`.gu` source:
+**Effects interface** — one method per declared `effect` or `action`. Each
+method gets a marker comment so downstream tooling can identify replay semantics
+without re-parsing the `.gu` source:
 
 ```go
 type OrderProcessorEffects interface {
+    // gust:effect -- replay-safe / idempotent
     ValidateOrder(order_id string) bool
-    // action -- not replay-safe / externally visible (#40).
+    // gust:action -- not replay-safe / externally visible
     ChargeCard(order_id string, amount_cents int64) (string, error)
 }
 ```
 
-The marker comment `// action -- not replay-safe / externally visible (#40).`
-appears on the line immediately before each action method. Runtimes that
-generate adapters from the interface can detect this comment to automatically
-wrap the implementation with checkpoint logic.
+The `gust:<kind>` marker appears on the line immediately before each effect or
+action method. Runtimes that generate adapters from the interface can detect
+these comments to automatically choose replay or checkpoint behavior.
 
 **Machine struct**
 

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -8,7 +8,7 @@ A machine has:
 - states
 - transitions
 - handlers (`on <transition>(...) { ... }`)
-- optional effects (`effect` or `async effect`)
+- optional effects and actions (`effect`, `action`, or their `async` forms)
 
 ```gust
 machine OrderFlow {
@@ -34,8 +34,11 @@ machine OrderFlow {
 }
 ```
 
-## v0.1.0 Focus
+## Current Focus
 
-`v0.1.0` provides a complete end-to-end workflow for building state machines in `.gu` and generating Rust/Go code with validation and tooling.
+`v0.2.0` provides a complete end-to-end workflow for building state machines in
+`.gu` and generating Rust/Go code with validation and tooling. It also adds
+workflow-runtime features such as `action`, handler-safety diagnostics,
+`EngineFailure`, JSON Schema generation, and `gust doctor`.
 
 Use `gust build --target <target>` to select generated output per platform. See the Appendix for current limitations and workarounds.

--- a/docs/src/reference/channels.md
+++ b/docs/src/reference/channels.md
@@ -1,6 +1,6 @@
 # Channels
 
-This page is part of the v0.1.0 documentation set for Gust.
+This page is part of the Gust documentation set.
 
 ```gust
 machine DocsExample {

--- a/docs/src/reference/effects_handlers.md
+++ b/docs/src/reference/effects_handlers.md
@@ -159,12 +159,34 @@ information is available.
 ## Code Generation
 
 Generated Rust and Go code exposes one effects interface per machine. Both
-`effect` and `action` declarations become methods on that interface. Action
-methods are marked in generated comments so host runtimes can preserve the
-semantic distinction.
+`effect` and `action` declarations become methods on that interface. Each method
+is marked in generated comments so host runtimes can preserve the semantic
+distinction.
 
 For example, a Rust target generates a trait whose methods are implemented by
-the host application. A Go target generates an interface with the same role.
+the host application. Each Rust trait method gets a machine-readable doc comment
+directly above it:
+
+```rust
+pub trait AuditEffects {
+    /// gust:effect -- replay-safe / idempotent
+    fn build_payload(&self) -> String;
+    /// gust:action -- not replay-safe / externally visible
+    fn write_audit(&self, payload: &str) -> String;
+}
+```
+
+A Go target generates an interface with the same role and marker format:
+
+```go
+type AuditEffects interface {
+    // gust:effect -- replay-safe / idempotent
+    BuildPayload() string
+    // gust:action -- not replay-safe / externally visible
+    WriteAudit(payload string) string
+}
+```
+
 The generated transition method receives that implementation and calls the
 declared methods while executing the handler body.
 

--- a/docs/src/reference/effects_handlers.md
+++ b/docs/src/reference/effects_handlers.md
@@ -1,16 +1,175 @@
 # Effects and Handlers
 
-This page is part of the v0.1.0 documentation set for Gust.
+Effects, actions, and handlers are the boundary between a Gust machine and the
+host application that runs generated code.
+
+Use this page as the language reference. For replay and checkpointing design,
+see [Workflow Runtime Integration](../guides/workflow_runtime.md).
+
+## Effects
+
+An `effect` declares an operation that the generated machine can call through
+the host application's effects interface.
 
 ```gust
-machine DocsExample {
-    state Start
-    state End
+machine OrderChecks {
+    state Pending(order_id: String)
+    state Accepted(order_id: String, token: String)
+    state Rejected(order_id: String, reason: String)
 
-    transition go: Start -> End
+    transition validate: Pending -> Accepted | Rejected
 
-    on go() {
-        goto End();
+    effect validate_order(order_id: String) -> Result<String, String>
+
+    on validate(ctx: ValidateCtx) {
+        let result = perform validate_order(ctx.order_id);
+        match result {
+            Ok(token) => {
+                goto Accepted(ctx.order_id, token);
+            }
+            Err(reason) => {
+                goto Rejected(ctx.order_id, reason);
+            }
+        }
     }
 }
 ```
+
+Effects are assumed to be replay-safe or idempotent. Typical examples are
+calculating a value, reading configuration, validating an input, or querying a
+service where repeated calls are acceptable for the surrounding runtime.
+
+Effects can be asynchronous:
+
+```gust
+machine AsyncCheck {
+    state Pending(id: String)
+    state Done(token: String)
+
+    transition validate: Pending -> Done
+
+    async effect fetch_token(id: String) -> String
+
+    async on validate(ctx: ValidateCtx) {
+        let token = perform fetch_token(ctx.id);
+        goto Done(token);
+    }
+}
+```
+
+## Actions
+
+An `action` has the same signature shape as an `effect`, but it marks an
+operation as non-idempotent or externally visible.
+
+```gust
+machine Approval {
+    state Waiting(step: String)
+    state Rejected(step: String, reason: String)
+
+    transition reject: Waiting -> Rejected
+
+    effect normalize_reason(reason: String) -> String
+    action notify_rejection(step: String, reason: String) -> String
+
+    on reject(ctx: RejectCtx, reason: String) {
+        let cleaned = perform normalize_reason(reason);
+        let receipt = perform notify_rejection(ctx.step, cleaned);
+        goto Rejected(ctx.step, receipt);
+    }
+}
+```
+
+Use `action` for work such as charging a card, sending an email, publishing a
+webhook, or recording an externally visible decision. Replay-aware runtimes can
+use the action marker to checkpoint before execution and restore the recorded
+result during replay instead of running the operation again.
+
+The validator emits warnings for two unsafe handler shapes:
+
+- More than one `action` on a single code path.
+- Any side-effectful step after an `action` on the same path.
+
+Branches are analyzed independently, so different actions in sibling `if` or
+`match` branches are allowed when only one branch can run.
+
+## Handlers
+
+A handler is an `on <transition>(...) { ... }` block. It defines the code that
+runs when the host application invokes a generated transition method.
+
+```gust
+machine Shipment {
+    state Charged(order_id: String)
+    state Shipped(order_id: String, tracking: String)
+    state Failed(order_id: String, reason: String)
+
+    transition ship: Charged -> Shipped | Failed
+
+    effect create_shipment(order_id: String) -> Result<String, String>
+
+    on ship(ctx: ShipCtx) {
+        let result = perform create_shipment(ctx.order_id);
+        match result {
+            Ok(tracking) => {
+                goto Shipped(ctx.order_id, tracking);
+            }
+            Err(reason) => {
+                goto Failed(ctx.order_id, reason);
+            }
+        }
+    }
+}
+```
+
+Handler parameters are explicit. By convention, examples use a transition
+context parameter such as `ctx: ShipCtx` when the handler needs fields from the
+current state. Additional event data can be passed as normal parameters.
+
+Handlers usually terminate each reachable branch with `goto <State>(...)`.
+The validator warns when declared transitions have no handler or when handler
+branches can fall through without transitioning.
+
+## `perform`
+
+Use `perform` to call either an effect or an action:
+
+```gust
+machine Audit {
+    state Ready
+    state Done(record_id: String)
+
+    transition record: Ready -> Done
+
+    effect build_payload() -> String
+    action write_audit(payload: String) -> String
+
+    on record() {
+        let payload = perform build_payload();
+        let record_id = perform write_audit(payload);
+        goto Done(record_id);
+    }
+}
+```
+
+`perform` can appear as a statement or inside an expression. When it appears in
+a `let` binding, the validator checks the declared return type when enough type
+information is available.
+
+## Code Generation
+
+Generated Rust and Go code exposes one effects interface per machine. Both
+`effect` and `action` declarations become methods on that interface. Action
+methods are marked in generated comments so host runtimes can preserve the
+semantic distinction.
+
+For example, a Rust target generates a trait whose methods are implemented by
+the host application. A Go target generates an interface with the same role.
+The generated transition method receives that implementation and calls the
+declared methods while executing the handler body.
+
+## Choosing `effect` or `action`
+
+Use `effect` when repeating the operation is safe for the runtime's semantics.
+Use `action` when repeating the operation could double-charge, duplicate a
+notification, publish a second event, or otherwise change the outside world.

--- a/docs/src/reference/errors.md
+++ b/docs/src/reference/errors.md
@@ -1,6 +1,6 @@
 # Errors
 
-This page is part of the v0.1.0 documentation set for Gust.
+This page is part of the Gust documentation set.
 
 ```gust
 machine DocsExample {

--- a/docs/src/reference/lifecycle.md
+++ b/docs/src/reference/lifecycle.md
@@ -1,6 +1,6 @@
 # Lifecycle
 
-This page is part of the v0.1.0 documentation set for Gust.
+This page is part of the Gust documentation set.
 
 ```gust
 machine DocsExample {

--- a/docs/src/reference/states_transitions.md
+++ b/docs/src/reference/states_transitions.md
@@ -1,6 +1,6 @@
 # States and Transitions
 
-This page is part of the v0.1.0 documentation set for Gust.
+This page is part of the Gust documentation set.
 
 ```gust
 machine DocsExample {

--- a/docs/src/reference/supervision.md
+++ b/docs/src/reference/supervision.md
@@ -1,6 +1,6 @@
 # Supervision Reference
 
-This page is part of the v0.1.0 documentation set for Gust.
+This page is part of the Gust documentation set.
 
 ```gust
 machine DocsExample {

--- a/docs/src/reference/types.md
+++ b/docs/src/reference/types.md
@@ -1,6 +1,6 @@
 # Types
 
-This page is part of the v0.1.0 documentation set for Gust.
+This page is part of the Gust documentation set.
 
 ```gust
 machine DocsExample {

--- a/docs/src/tutorial/adding_effects.md
+++ b/docs/src/tutorial/adding_effects.md
@@ -1,6 +1,6 @@
 # Adding Effects
 
-This page is part of the v0.1.0 documentation set for Gust.
+This page is part of the Gust documentation set.
 
 ```gust
 machine DocsExample {

--- a/docs/src/tutorial/async.md
+++ b/docs/src/tutorial/async.md
@@ -1,6 +1,6 @@
 # Async
 
-This page is part of the v0.1.0 documentation set for Gust.
+This page is part of the Gust documentation set.
 
 ```gust
 machine DocsExample {

--- a/docs/src/tutorial/deployment.md
+++ b/docs/src/tutorial/deployment.md
@@ -1,6 +1,6 @@
 # Deployment
 
-This page is part of the v0.1.0 documentation set for Gust.
+This page is part of the Gust documentation set.
 
 ```gust
 machine DocsExample {

--- a/docs/src/tutorial/first_machine.md
+++ b/docs/src/tutorial/first_machine.md
@@ -1,6 +1,6 @@
 # First Machine
 
-This page is part of the v0.1.0 documentation set for Gust.
+This page is part of the Gust documentation set.
 
 ```gust
 machine DocsExample {

--- a/docs/src/tutorial/getting_started.md
+++ b/docs/src/tutorial/getting_started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-This page is part of the v0.1.0 documentation set for Gust.
+This page is part of the Gust documentation set.
 
 ```gust
 machine DocsExample {

--- a/docs/src/tutorial/supervision.md
+++ b/docs/src/tutorial/supervision.md
@@ -1,6 +1,6 @@
 # Supervision
 
-This page is part of the v0.1.0 documentation set for Gust.
+This page is part of the Gust documentation set.
 
 ```gust
 machine DocsExample {

--- a/docs/src/tutorial/testing.md
+++ b/docs/src/tutorial/testing.md
@@ -1,6 +1,6 @@
 # Testing
 
-This page is part of the v0.1.0 documentation set for Gust.
+This page is part of the Gust documentation set.
 
 ```gust
 machine DocsExample {

--- a/examples/event_processor/src/processor.g.rs
+++ b/examples/event_processor/src/processor.g.rs
@@ -33,7 +33,9 @@ pub enum EventProcessorState {
 }
 
 pub trait EventProcessorEffects {
+    /// gust:effect -- replay-safe / idempotent
     fn validate_event(&self, event: &Event) -> String;
+    /// gust:effect -- replay-safe / idempotent
     fn process_event(&self, event: &Event) -> ProcessedResult;
 }
 

--- a/examples/microservice/src/order.g.rs
+++ b/examples/microservice/src/order.g.rs
@@ -44,8 +44,11 @@ pub enum OrderMachineState {
 }
 
 pub trait OrderMachineEffects {
+    /// gust:effect -- replay-safe / idempotent
     fn calculate_total(&self, order: &Order) -> Money;
+    /// gust:effect -- replay-safe / idempotent
     fn process_payment(&self, total: &Money) -> Receipt;
+    /// gust:effect -- replay-safe / idempotent
     fn create_shipment(&self, order: &Order) -> String;
 }
 

--- a/examples/microservice/src/payment.g.rs
+++ b/examples/microservice/src/payment.g.rs
@@ -32,7 +32,9 @@ pub enum PaymentMachineState {
 }
 
 pub trait PaymentMachineEffects {
+    /// gust:effect -- replay-safe / idempotent
     fn initiate_charge(&self, amount: &PayMoney) -> String;
+    /// gust:effect -- replay-safe / idempotent
     fn confirm_charge(&self, tx_id: &str, amount: &PayMoney) -> PayReceipt;
 }
 

--- a/examples/order_processor.g.go
+++ b/examples/order_processor.g.go
@@ -77,8 +77,11 @@ type OrderProcessorFailedData struct {
 }
 
 type OrderProcessorEffects interface {
+	// gust:effect -- replay-safe / idempotent
 	CalculateTotal(order Order) Money
+	// gust:effect -- replay-safe / idempotent
 	ProcessPayment(total Money) Receipt
+	// gust:effect -- replay-safe / idempotent
 	CreateShipment(order Order) string
 }
 
@@ -128,10 +131,11 @@ func (m *OrderProcessor) Validate(effects OrderProcessorEffects) error {
 
 	total := effects.CalculateTotal(m.PendingData.Order)
 	if total.Cents > 0 {
+		var __goto_validated_order Order = m.PendingData.Order
 		m.State = OrderProcessorStateValidated
 		m.clearStateData()
 		m.ValidatedData = &OrderProcessorValidatedData{
-			Order: m.PendingData.Order,
+			Order: __goto_validated_order,
 			Total: total,
 		}
 	} else {
@@ -151,10 +155,11 @@ func (m *OrderProcessor) Charge(effects OrderProcessorEffects) error {
 	}
 
 	receipt := effects.ProcessPayment(m.ValidatedData.Total)
+	var __goto_charged_order Order = m.ValidatedData.Order
 	m.State = OrderProcessorStateCharged
 	m.clearStateData()
 	m.ChargedData = &OrderProcessorChargedData{
-		Order: m.ValidatedData.Order,
+		Order: __goto_charged_order,
 		Payment: receipt,
 	}
 
@@ -167,10 +172,11 @@ func (m *OrderProcessor) Ship(effects OrderProcessorEffects) error {
 	}
 
 	tracking := effects.CreateShipment(m.ChargedData.Order)
+	var __goto_shipped_order Order = m.ChargedData.Order
 	m.State = OrderProcessorStateShipped
 	m.clearStateData()
 	m.ShippedData = &OrderProcessorShippedData{
-		Order: m.ChargedData.Order,
+		Order: __goto_shipped_order,
 		Tracking: tracking,
 	}
 

--- a/examples/order_processor.g.rs
+++ b/examples/order_processor.g.rs
@@ -44,8 +44,11 @@ pub enum OrderProcessorState {
 }
 
 pub trait OrderProcessorEffects {
+    /// gust:effect -- replay-safe / idempotent
     fn calculate_total(&self, order: &Order) -> Money;
+    /// gust:effect -- replay-safe / idempotent
     fn process_payment(&self, total: &Money) -> Receipt;
+    /// gust:effect -- replay-safe / idempotent
     fn create_shipment(&self, order: &Order) -> String;
 }
 
@@ -105,7 +108,7 @@ impl OrderProcessor {
 
     pub fn ship(&mut self, effects: &impl OrderProcessorEffects) -> Result<(), OrderProcessorError> {
         match self.state.clone() {
-            OrderProcessorState::Charged { order, payment } => {
+            OrderProcessorState::Charged { order, payment: _payment } => {
                 let tracking = effects.create_shipment(&order);
                 self.state = OrderProcessorState::Shipped { order: order, tracking: tracking };
                 Ok(())
@@ -119,7 +122,7 @@ impl OrderProcessor {
 
     pub fn retry(&mut self, original_order: Order) -> Result<(), OrderProcessorError> {
         match self.state.clone() {
-            OrderProcessorState::Failed { reason } => {
+            OrderProcessorState::Failed { reason: _reason } => {
                 self.state = OrderProcessorState::Pending { order: original_order };
                 Ok(())
             }
@@ -167,7 +170,7 @@ impl OrderSupervisor {
 
     pub fn order_failed(&mut self) -> Result<(), OrderSupervisorError> {
         match self.state.clone() {
-            OrderSupervisorState::Watching { active_orders } => {
+            OrderSupervisorState::Watching { active_orders: _active_orders } => {
                 // Cannot auto-transition to Watching - requires fields
                 Ok(())
             }
@@ -180,7 +183,7 @@ impl OrderSupervisor {
 
     pub fn recover(&mut self) -> Result<(), OrderSupervisorError> {
         match self.state.clone() {
-            OrderSupervisorState::Degraded { failed_count } => {
+            OrderSupervisorState::Degraded { failed_count: _failed_count } => {
                 // Cannot auto-transition to Watching - requires fields
                 Ok(())
             }
@@ -193,7 +196,7 @@ impl OrderSupervisor {
 
     pub fn kill(&mut self) -> Result<(), OrderSupervisorError> {
         match self.state.clone() {
-            OrderSupervisorState::Degraded { failed_count } => {
+            OrderSupervisorState::Degraded { failed_count: _failed_count } => {
                 self.state = OrderSupervisorState::Shutdown;
                 Ok(())
             }

--- a/examples/workflow_engine/README.md
+++ b/examples/workflow_engine/README.md
@@ -20,7 +20,7 @@ action notify_rejection(step_name: String, reason: String) -> String
 ```
 
 The generated `WorkflowEngineEffects` trait marks this method with a doc comment:
-`/// action — not replay-safe / externally visible (#40)`.
+`/// gust:action -- not replay-safe / externally visible`.
 
 ### `EngineFailure` — typed workflow failure
 

--- a/examples/workflow_engine/src/workflow.g.rs
+++ b/examples/workflow_engine/src/workflow.g.rs
@@ -20,6 +20,7 @@ pub enum StepRunnerState {
 }
 
 pub trait StepRunnerEffects {
+    /// gust:effect -- replay-safe / idempotent
     fn run_step(&self, step: &str) -> String;
 }
 
@@ -97,11 +98,15 @@ pub enum WorkflowEngineState {
 }
 
 pub trait WorkflowEngineEffects {
+    /// gust:effect -- replay-safe / idempotent
     fn execute_step(&self, step_name: &str) -> String;
+    /// gust:effect -- replay-safe / idempotent
     fn needs_approval(&self, step_name: &str) -> bool;
+    /// gust:effect -- replay-safe / idempotent
     fn next_step_name(&self, current_step: &str) -> String;
+    /// gust:effect -- replay-safe / idempotent
     fn produce_failure(&self, reason: &str) -> EngineFailure;
-    /// action — not replay-safe / externally visible (#40).
+    /// gust:action -- not replay-safe / externally visible
     fn notify_rejection(&self, step_name: &str, reason: &str) -> String;
 }
 

--- a/gust-lang/src/ast.rs
+++ b/gust-lang/src/ast.rs
@@ -203,6 +203,14 @@ impl EffectKind {
             EffectKind::Action => "action",
         }
     }
+
+    /// Stable generated-code annotation text for downstream tooling.
+    pub fn annotation_description(self) -> &'static str {
+        match self {
+            EffectKind::Effect => "replay-safe / idempotent",
+            EffectKind::Action => "not replay-safe / externally visible",
+        }
+    }
 }
 
 /// An `effect` or `action` declaration inside a machine.

--- a/gust-lang/src/codegen.rs
+++ b/gust-lang/src/codegen.rs
@@ -381,11 +381,13 @@ pub enum {name}Error {{
             } else {
                 format!(" -> {return_type}")
             };
-            // Mark actions in rustdoc so downstream tooling and humans can
-            // tell them apart without re-parsing the .gu source. See #40.
-            if matches!(effect.kind, EffectKind::Action) {
-                self.line("/// action — not replay-safe / externally visible (#40).");
-            }
+            // Keep the annotation directly above the method so downstream
+            // tooling can parse generated Rust without reading .gu source.
+            self.line(&format!(
+                "/// gust:{} -- {}",
+                effect.kind.keyword(),
+                effect.kind.annotation_description()
+            ));
             self.line(&format!(
                 "{}fn {}({}){};",
                 if effect.is_async { "async " } else { "" },

--- a/gust-lang/src/codegen_go.rs
+++ b/gust-lang/src/codegen_go.rs
@@ -523,11 +523,13 @@ impl GoCodegen {
             );
             let is_unit = matches!(effect.return_type, TypeExpr::Unit);
             let return_type = self.type_expr_to_go(&effect.return_type);
-            // Mark actions in the generated comment so downstream tooling can
-            // tell them apart without re-parsing the .gu source. See #40.
-            if matches!(effect.kind, EffectKind::Action) {
-                self.line("// action -- not replay-safe / externally visible (#40).");
-            }
+            // Keep the annotation directly above the method so downstream
+            // tooling can parse generated Go without reading .gu source.
+            self.line(&format!(
+                "// gust:{} -- {}",
+                effect.kind.keyword(),
+                effect.kind.annotation_description()
+            ));
             if effect.is_async {
                 if is_unit {
                     self.line(&format!("{}({}) error", method_name, params.join(", "),));

--- a/gust-lang/tests/action_codegen_metadata.rs
+++ b/gust-lang/tests/action_codegen_metadata.rs
@@ -47,8 +47,8 @@ fn rust_codegen_marks_action_methods() {
 
     // The action method carries the marker comment.
     assert!(
-        code.contains("/// action — not replay-safe / externally visible (#40)."),
-        "Rust codegen should mark action methods with a rustdoc comment. Got:\n{code}"
+        code.contains("/// gust:action -- not replay-safe / externally visible"),
+        "Rust codegen should mark action methods with a machine-readable rustdoc comment. Got:\n{code}"
     );
 
     // The marker appears immediately before the `publish` method.
@@ -59,7 +59,7 @@ fn rust_codegen_marks_action_methods() {
         .expect("should emit `fn publish`");
     assert!(publish_idx > 0, "publish should not be at line 0");
     assert!(
-        lines[publish_idx - 1].contains("action — not replay-safe"),
+        lines[publish_idx - 1].contains("/// gust:action -- not replay-safe / externally visible"),
         "marker should be directly above fn publish, got:\n{}\n{}",
         lines[publish_idx - 1],
         lines[publish_idx]
@@ -71,7 +71,11 @@ fn rust_codegen_does_not_mark_plain_effect_methods() {
     let program = parse_program(ONLY_EFFECT_SRC).expect("should parse");
     let code = RustCodegen::new().generate(&program);
     assert!(
-        !code.contains("action — not replay-safe"),
+        code.contains("/// gust:effect -- replay-safe / idempotent"),
+        "plain effects must be marked with effect annotations. Got:\n{code}"
+    );
+    assert!(
+        !code.contains("/// gust:action"),
         "plain effects must not be marked as actions. Got:\n{code}"
     );
     assert!(code.contains("fn compute"));
@@ -83,7 +87,7 @@ fn go_codegen_marks_action_methods() {
     let code = GoCodegen::new().generate(&program, "hybrid");
 
     assert!(
-        code.contains("// action -- not replay-safe / externally visible (#40)."),
+        code.contains("// gust:action -- not replay-safe / externally visible"),
         "Go codegen should mark action methods with a // comment. Got:\n{code}"
     );
 
@@ -95,7 +99,7 @@ fn go_codegen_marks_action_methods() {
         .expect("Publish method should be generated");
     assert!(publish_idx > 0, "Publish should not be at line 0");
     assert!(
-        lines[publish_idx - 1].contains("action -- not replay-safe"),
+        lines[publish_idx - 1].contains("// gust:action -- not replay-safe / externally visible"),
         "marker should precede Publish, got:\n{}\n{}",
         lines[publish_idx - 1],
         lines[publish_idx]
@@ -107,7 +111,11 @@ fn go_codegen_does_not_mark_plain_effect_methods() {
     let program = parse_program(ONLY_EFFECT_SRC).expect("should parse");
     let code = GoCodegen::new().generate(&program, "pure");
     assert!(
-        !code.contains("action -- not replay-safe"),
+        code.contains("// gust:effect -- replay-safe / idempotent"),
+        "plain Go effects must be marked with effect annotations. Got:\n{code}"
+    );
+    assert!(
+        !code.contains("// gust:action"),
         "plain effects must not be marked as actions. Got:\n{code}"
     );
 }
@@ -118,12 +126,16 @@ fn codegen_marker_count_matches_action_count() {
     let rust_code = RustCodegen::new().generate(&program);
     let go_code = GoCodegen::new().generate(&program, "hybrid");
 
-    let rust_markers = rust_code.matches("action — not replay-safe").count();
-    let go_markers = go_code.matches("action -- not replay-safe").count();
+    let rust_action_markers = rust_code.matches("/// gust:action").count();
+    let rust_effect_markers = rust_code.matches("/// gust:effect").count();
+    let go_action_markers = go_code.matches("// gust:action").count();
+    let go_effect_markers = go_code.matches("// gust:effect").count();
 
-    // One `action publish` → exactly one marker per target.
-    assert_eq!(rust_markers, 1, "Rust: expected 1 action marker");
-    assert_eq!(go_markers, 1, "Go: expected 1 action marker");
+    // One `effect compute` and one `action publish` → exactly one marker each.
+    assert_eq!(rust_action_markers, 1, "Rust: expected 1 action marker");
+    assert_eq!(rust_effect_markers, 1, "Rust: expected 1 effect marker");
+    assert_eq!(go_action_markers, 1, "Go: expected 1 action marker");
+    assert_eq!(go_effect_markers, 1, "Go: expected 1 effect marker");
 }
 
 #[test]
@@ -147,5 +159,55 @@ machine OnlyActions {
     let code = RustCodegen::new().generate(&program);
     assert!(code.contains("pub trait OnlyActionsEffects"));
     assert!(code.contains("fn publish"));
-    assert!(code.contains("action — not replay-safe"));
+    assert!(code.contains("/// gust:action -- not replay-safe / externally visible"));
+}
+
+#[test]
+fn rust_codegen_places_kind_annotations_above_every_trait_method() {
+    let program = parse_program(MIXED_SRC).expect("should parse");
+    let code = RustCodegen::new().generate(&program);
+    let lines: Vec<&str> = code.lines().collect();
+
+    let compute_idx = lines
+        .iter()
+        .position(|l| l.contains("fn compute"))
+        .expect("should emit `fn compute`");
+    let publish_idx = lines
+        .iter()
+        .position(|l| l.contains("fn publish"))
+        .expect("should emit `fn publish`");
+
+    assert_eq!(
+        lines[compute_idx - 1].trim(),
+        "/// gust:effect -- replay-safe / idempotent"
+    );
+    assert_eq!(
+        lines[publish_idx - 1].trim(),
+        "/// gust:action -- not replay-safe / externally visible"
+    );
+}
+
+#[test]
+fn go_codegen_places_kind_annotations_above_every_interface_method() {
+    let program = parse_program(MIXED_SRC).expect("should parse");
+    let code = GoCodegen::new().generate(&program, "hybrid");
+    let lines: Vec<&str> = code.lines().collect();
+
+    let compute_idx = lines
+        .iter()
+        .position(|l| l.contains("Compute("))
+        .expect("should emit `Compute`");
+    let publish_idx = lines
+        .iter()
+        .position(|l| l.contains("Publish("))
+        .expect("should emit `Publish`");
+
+    assert_eq!(
+        lines[compute_idx - 1].trim(),
+        "// gust:effect -- replay-safe / idempotent"
+    );
+    assert_eq!(
+        lines[publish_idx - 1].trim(),
+        "// gust:action -- not replay-safe / externally visible"
+    );
 }


### PR DESCRIPTION
Closes #74. Adds machine-readable gust:<kind> comments to generated Rust trait methods and Go interface methods, including replay-safe/idempotent text for effects and not replay-safe/externally visible text for actions. Updates generated examples and docs. Validation: cargo test -p gust-lang --test action_codegen_metadata; cargo test -p gust-lang --test generated_code_compilation; cargo test -p gust-lang --test docs_snippets; cargo test --manifest-path examples/event_processor/Cargo.toml; cargo test --manifest-path examples/microservice/Cargo.toml; cargo test --manifest-path examples/workflow_engine/Cargo.toml; git diff --check.